### PR TITLE
feat: Parser 인터페이스 및 타입 정의 (Phase 4)

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,7 +1,10 @@
 // Package parser provides code parsing capabilities for brfit.
 package parser
 
-import "sync"
+import (
+	"path/filepath"
+	"sync"
+)
 
 // Signature represents an extracted code signature (function, class, method, etc.).
 type Signature struct {
@@ -149,4 +152,34 @@ func RegisterParser(lang string, parser Parser) {
 // GetParser returns a parser from the default registry.
 func GetParser(lang string) (Parser, bool) {
 	return defaultRegistry.Get(lang)
+}
+
+// LanguageMapping maps file extensions to language names.
+var LanguageMapping = map[string]string{
+	".go":    "go",
+	".ts":    "typescript",
+	".tsx":   "tsx",
+	".js":    "javascript",
+	".jsx":   "jsx",
+	".py":    "python",
+	".java":  "java",
+	".rs":    "rust",
+	".rb":    "ruby",
+	".php":   "php",
+	".c":     "c",
+	".cpp":   "cpp",
+	".h":     "c",
+	".hpp":   "cpp",
+	".cs":    "csharp",
+	".swift": "swift",
+	".kt":    "kotlin",
+}
+
+// DetectLanguage returns the language for a given file path.
+func DetectLanguage(path string) string {
+	ext := filepath.Ext(path)
+	if lang, ok := LanguageMapping[ext]; ok {
+		return lang
+	}
+	return ""
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -127,3 +127,27 @@ func TestDefaultRegistry(t *testing.T) {
 		t.Fatal("expected non-nil registry")
 	}
 }
+
+func TestDetectLanguage(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"main.go", "go"},
+		{"app.ts", "typescript"},
+		{"component.tsx", "tsx"},
+		{"index.js", "javascript"},
+		{"App.jsx", "jsx"},
+		{"README.md", ""},
+		{"config.json", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			lang := DetectLanguage(tt.path)
+			if lang != tt.expected {
+				t.Errorf("expected language '%s', got '%s'", tt.expected, lang)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🚀 개요 (Overview)

  - 기능: pkg/parser 패키지 구현 - 코드 파싱을 위한 인터페이스, 타입, Registry, 언어 감지 유틸리티

  🛠️ 작업 내용 (Changes)

  이번 PR에서 변경된 핵심 내용을 요약해주세요.

  - Task 1: Parser 타입 정의 (Signature, Node, ParseResult, Options)
  - Task 2: Parser 인터페이스 정의 (Parse, Languages 메서드)
  - Task 3: Registry 구조체 및 Factory 함수 구현 (NewRegistry, DefaultRegistry, RegisterParser, GetParser)
  - Task 4: 언어 감지 유틸리티 구현 (DetectLanguage, LanguageMapping)

## 🏗️ 아키텍처/설계 결정 (Architectural Decisions)

  - 인터페이스 기반 설계: Parser 인터페이스를 정의하여 Tree-sitter 외에도 다른 파서(dotenv, yaml 등)를 추가할 수 있게 설계
  - 스레드 안전한 Registry: sync.RWMutex를 사용하여 향후 여러 파일을 병렬(Goroutine)로 파싱할 때 스레드 안전성 보장
  - 불변 결과: ParseResult는 파싱 완료 후 수정되지 않는 불변 객체로 설계
  - Signature 범위 정보: Line(시작)과 EndLine(끝)을 모두 포함하여 AI에게 정확한 코드 블록 범위 제공

## 🧪 테스트 결과 (Testing)

  - 유닛 테스트: go test ./pkg/parser/... 통과
  - 빌드 테스트: go build ./... 성공
  - 정적 분석: go vet ./... 경고 없음
  - 포맷팅: gofmt -l . 문제 없음

### 테스트 실행 결과
```
  $ go test ./pkg/parser/... -v
  === RUN   TestSignatureDefaults
  --- PASS: TestSignatureDefaults (0.00s)
  === RUN   TestParseResultDefaults
  --- PASS: TestParseResultDefaults (0.00s)
  === RUN   TestNodeKind
  --- PASS: TestNodeKind (0.00s)
  === RUN   TestParserInterface
  --- PASS: TestParserInterface (0.00s)
  === RUN   TestMockParser
  --- PASS: TestMockParser (0.00s)
  === RUN   TestRegistry
  --- PASS: TestRegistry (0.00s)
  === RUN   TestDefaultRegistry
  --- PASS: TestDefaultRegistry (0.00s)
  === RUN   TestDetectLanguage
  --- PASS: TestDetectLanguage (0.00s)
  PASS
  ok      brf.it/pkg/parser       0.002s
```

## ✅ 체크리스트 (Final Checklist)

  - 코드가 프로젝트 컨벤션(Go 스타일)을 준수하는가?
  - 커밋 메시지가 feat:, chore:, fix: 등의 형식을 따르는가?
  - 불필요한 로그나 주석을 제거했는가?