### PR TITLE
feat: Formatter 인터페이스 및 XML/Markdown 포맷터 구현 (Phase-7)

### DIFF
--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -1,0 +1,45 @@
+// Package formatter provides output formatting for brfit.
+package formatter
+
+import (
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// FileData represents a file with its extracted data for formatting.
+type FileData struct {
+	// Path is the file path.
+	Path string
+
+	// Language is the detected language.
+	Language string
+
+	// Signatures is the list of extracted signatures.
+	Signatures []parser.Signature
+
+	// Error is any error that occurred during extraction.
+	Error error
+}
+
+// PackageData contains all data needed for formatting output.
+type PackageData struct {
+	// Tree is the directory tree string.
+	Tree string
+
+	// Files is the list of file data.
+	Files []FileData
+
+	// TotalSignatures is the total number of signatures.
+	TotalSignatures int
+
+	// TotalSize is the total size of processed files.
+	TotalSize int64
+}
+
+// Formatter defines the interface for output formatting.
+type Formatter interface {
+	// Format formats the package data and returns the output bytes.
+	Format(data *PackageData) ([]byte, error)
+
+	// Name returns the formatter name (e.g., "xml", "markdown").
+	Name() string
+}

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -1,0 +1,257 @@
+package formatter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+func TestXMLFormatterImplementsFormatter(t *testing.T) {
+	var _ Formatter = (*XMLFormatter)(nil)
+}
+
+func TestMarkdownFormatterImplementsFormatter(t *testing.T) {
+	var _ Formatter = (*MarkdownFormatter)(nil)
+}
+
+func TestXMLFormatterFormat(t *testing.T) {
+	formatter := NewXMLFormatter()
+
+	data := &PackageData{
+		Tree: "pkg/\n└── test.go",
+		Files: []FileData{
+			{
+				Path:     "pkg/test.go",
+				Language: "go",
+				Signatures: []parser.Signature{
+					{
+						Name:     "Add",
+						Kind:     "function",
+						Text:     "func Add(a, b int) int",
+						Doc:      "Add returns the sum of two integers.",
+						Line:     5,
+						Language: "go",
+						Exported: true,
+					},
+				},
+			},
+		},
+		TotalSignatures: 1,
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify XML structure
+	outputStr := string(output)
+
+	if !strings.Contains(outputStr, `<?xml version="1.0"`) {
+		t.Error("expected XML declaration")
+	}
+
+	if !strings.Contains(outputStr, "<brfit>") {
+		t.Error("expected <brfit> root element")
+	}
+
+	if !strings.Contains(outputStr, "<metadata>") {
+		t.Error("expected <metadata> element")
+	}
+
+	if !strings.Contains(outputStr, `<file path="pkg/test.go" language="go"`) {
+		t.Error("expected file element with path and language attributes")
+	}
+
+	if !strings.Contains(outputStr, "<signature>func Add(a, b int) int</signature>") {
+		t.Error("expected signature element")
+	}
+
+	if !strings.Contains(outputStr, "<doc>Add returns the sum of two integers.</doc>") {
+		t.Error("expected doc element")
+	}
+}
+
+func TestXMLFormatterFormatWithError(t *testing.T) {
+	formatter := NewXMLFormatter()
+
+	data := &PackageData{
+		Files: []FileData{
+			{
+				Path:     "test.py",
+				Language: "python",
+				Error:    fmt.Errorf("no parser for language: python"),
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "<error>no parser for language: python</error>") {
+		t.Error("expected error element")
+	}
+}
+
+func TestMarkdownFormatterFormat(t *testing.T) {
+	formatter := NewMarkdownFormatter()
+
+	data := &PackageData{
+		Tree: "pkg/\n└── test.go",
+		Files: []FileData{
+			{
+				Path:     "pkg/test.go",
+				Language: "go",
+				Signatures: []parser.Signature{
+					{
+						Name:     "Add",
+						Kind:     "function",
+						Text:     "func Add(a, b int) int",
+						Doc:      "Add returns the sum.",
+						Line:     5,
+						Language: "go",
+						Exported: true,
+					},
+				},
+			},
+		},
+		TotalSignatures: 1,
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+
+	if !strings.Contains(outputStr, "# Brf.it Output") {
+		t.Error("expected header")
+	}
+
+	if !strings.Contains(outputStr, "## Directory Tree") {
+		t.Error("expected Directory Tree section")
+	}
+
+	if !strings.Contains(outputStr, "## Symbols") {
+		t.Error("expected Symbols section")
+	}
+
+	if !strings.Contains(outputStr, "## Files") {
+		t.Error("expected Files section")
+	}
+
+	if !strings.Contains(outputStr, "### pkg/test.go") {
+		t.Error("expected file path as heading")
+	}
+
+	if !strings.Contains(outputStr, "```go") {
+		t.Error("expected code block with language")
+	}
+
+	if !strings.Contains(outputStr, "func Add(a, b int) int") {
+		t.Error("expected signature in code block")
+	}
+}
+
+func TestFormatterNames(t *testing.T) {
+	xmlFormatter := NewXMLFormatter()
+	if xmlFormatter.Name() != "xml" {
+		t.Errorf("expected name 'xml', got '%s'", xmlFormatter.Name())
+	}
+
+	mdFormatter := NewMarkdownFormatter()
+	if mdFormatter.Name() != "markdown" {
+		t.Errorf("expected name 'markdown', got '%s'", mdFormatter.Name())
+	}
+}
+
+func TestXMLFormatterEscapeXML(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello", "hello"},
+		{"a & b", "a &amp; b"},
+		{"<tag>", "&lt;tag&gt;"},
+		{`"quoted"`, "&quot;quoted&quot;"},
+		{"it's", "it&apos;s"},
+		{"all & < > \" '", "all &amp; &lt; &gt; &quot; &apos;"},
+	}
+
+	for _, tt := range tests {
+		result := escapeXML(tt.input)
+		if result != tt.expected {
+			t.Errorf("escapeXML(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestMarkdownFormatterEscapeMarkdown(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello", "hello"},
+		{"code `here`", "code \\`here\\`"},
+		{"no escape needed", "no escape needed"},
+	}
+
+	for _, tt := range tests {
+		result := escapeMarkdown(tt.input)
+		if result != tt.expected {
+			t.Errorf("escapeMarkdown(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestXMLFormatterEmptyData(t *testing.T) {
+	formatter := NewXMLFormatter()
+
+	data := &PackageData{
+		Files: []FileData{},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+
+	if !strings.Contains(outputStr, "<brfit>") {
+		t.Error("expected <brfit> root element")
+	}
+
+	if !strings.Contains(outputStr, "<files>\n  </files>") {
+		t.Error("expected empty files section")
+	}
+}
+
+func TestMarkdownFormatterEmptyData(t *testing.T) {
+	formatter := NewMarkdownFormatter()
+
+	data := &PackageData{
+		Files: []FileData{},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+
+	if !strings.Contains(outputStr, "# Brf.it Output") {
+		t.Error("expected header")
+	}
+
+	if !strings.Contains(outputStr, "## Files") {
+		t.Error("expected Files section")
+	}
+}

--- a/pkg/formatter/markdown.go
+++ b/pkg/formatter/markdown.go
@@ -1,0 +1,87 @@
+package formatter
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// MarkdownFormatter implements Formatter for Markdown output.
+type MarkdownFormatter struct{}
+
+// NewMarkdownFormatter creates a new MarkdownFormatter.
+func NewMarkdownFormatter() *MarkdownFormatter {
+	return &MarkdownFormatter{}
+}
+
+// Name returns the formatter name.
+func (f *MarkdownFormatter) Name() string {
+	return "markdown"
+}
+
+// Format implements Formatter interface.
+func (f *MarkdownFormatter) Format(data *PackageData) ([]byte, error) {
+	var buf bytes.Buffer
+
+	buf.WriteString("# Brf.it Output\n\n")
+
+	// Directory Tree
+	if data.Tree != "" {
+		buf.WriteString("## Directory Tree\n\n")
+		buf.WriteString("```\n")
+		buf.WriteString(data.Tree)
+		buf.WriteString("\n```\n\n")
+	}
+
+	// Symbols
+	if data.TotalSignatures > 0 {
+		buf.WriteString("## Symbols\n\n")
+		for _, file := range data.Files {
+			for _, sig := range file.Signatures {
+				buf.WriteString("- `")
+				buf.WriteString(escapeMarkdown(sig.Text))
+				buf.WriteString("`\n")
+			}
+		}
+		buf.WriteString("\n---\n\n")
+	}
+
+	// Files
+	buf.WriteString("## Files\n\n")
+	for _, file := range data.Files {
+		buf.WriteString(fmt.Sprintf("### %s\n\n", file.Path))
+
+		if file.Error != nil {
+			buf.WriteString("> **Error:** ")
+			buf.WriteString(escapeMarkdown(file.Error.Error()))
+			buf.WriteString("\n\n")
+		} else {
+			buf.WriteString(fmt.Sprintf("```%s\n", file.Language))
+			for _, sig := range file.Signatures {
+				buf.WriteString(sig.Text)
+				buf.WriteString("\n")
+			}
+			buf.WriteString("```\n\n")
+
+			// Add docs as quotes
+			for _, sig := range file.Signatures {
+				if sig.Doc != "" {
+					buf.WriteString("> ")
+					buf.WriteString(escapeMarkdown(sig.Doc))
+					buf.WriteString("\n\n")
+				}
+			}
+		}
+
+		buf.WriteString("---\n\n")
+	}
+
+	return buf.Bytes(), nil
+}
+
+// escapeMarkdown escapes special characters for Markdown content.
+func escapeMarkdown(s string) string {
+	// Only escape backticks to avoid breaking code blocks
+	s = strings.ReplaceAll(s, "`", "\\`")
+	return s
+}

--- a/pkg/formatter/xml.go
+++ b/pkg/formatter/xml.go
@@ -1,0 +1,95 @@
+package formatter
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// XMLFormatter implements Formatter for XML output.
+type XMLFormatter struct{}
+
+// NewXMLFormatter creates a new XMLFormatter.
+func NewXMLFormatter() *XMLFormatter {
+	return &XMLFormatter{}
+}
+
+// Name returns the formatter name.
+func (f *XMLFormatter) Name() string {
+	return "xml"
+}
+
+// Format implements Formatter interface.
+func (f *XMLFormatter) Format(data *PackageData) ([]byte, error) {
+	var buf bytes.Buffer
+
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	buf.WriteByte('\n')
+	buf.WriteString("<brfit>\n")
+
+	// Metadata section
+	buf.WriteString("  <metadata>\n")
+
+	// Tree
+	if data.Tree != "" {
+		buf.WriteString("    <tree>")
+		buf.WriteString(escapeXML(data.Tree))
+		buf.WriteString("</tree>\n")
+	}
+
+	// Symbols summary
+	if data.TotalSignatures > 0 {
+		buf.WriteString("    <symbols>\n")
+		for _, file := range data.Files {
+			for _, sig := range file.Signatures {
+				buf.WriteString("      - ")
+				buf.WriteString(escapeXML(sig.Text))
+				buf.WriteByte('\n')
+			}
+		}
+		buf.WriteString("    </symbols>\n")
+	}
+
+	buf.WriteString("  </metadata>\n")
+
+	// Files section
+	buf.WriteString("  <files>\n")
+	for _, file := range data.Files {
+		buf.WriteString(fmt.Sprintf("    <file path=%q language=%q>\n", file.Path, file.Language))
+
+		if file.Error != nil {
+			buf.WriteString("      <error>")
+			buf.WriteString(escapeXML(file.Error.Error()))
+			buf.WriteString("</error>\n")
+		} else {
+			for _, sig := range file.Signatures {
+				buf.WriteString("      <signature>")
+				buf.WriteString(escapeXML(sig.Text))
+				buf.WriteString("</signature>\n")
+
+				if sig.Doc != "" {
+					buf.WriteString("      <doc>")
+					buf.WriteString(escapeXML(sig.Doc))
+					buf.WriteString("</doc>\n")
+				}
+			}
+		}
+
+		buf.WriteString("    </file>\n")
+	}
+	buf.WriteString("  </files>\n")
+
+	buf.WriteString("</brfit>\n")
+
+	return buf.Bytes(), nil
+}
+
+// escapeXML escapes special characters for XML content.
+func escapeXML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	return s
+}


### PR DESCRIPTION
## 🚀 개요 (Overview)

  - **기능**: 추출된 코드 데이터를 XML 및 Markdown 포맷으로 변환하는 Formatter 패키지 구현

  ## 🛠️ 작업 내용 (Changes)

  - [x] `pkg/formatter/formatter.go` - Formatter 인터페이스 및 FileData, PackageData 타입 정의
  - [x] `pkg/formatter/xml.go` - XMLFormatter 구현 (XML 이스케이프 처리 포함)
  - [x] `pkg/formatter/markdown.go` - MarkdownFormatter 구현 (언어별 코드 블록 지원)
  - [x] `pkg/formatter/formatter_test.go` - 단위 테스트 작성 (10개 테스트 케이스)

  ## 🏗️ 아키텍처/설계 결정 (Architectural Decisions)

  - **인터페이스 기반 설계**: `Formatter` 인터페이스를 정의하여 향후 JSON 등 다른 포맷 추가가 용이하도록 함
  - **문자열 빌더 활용**: `bytes.Buffer`로 직접 빌드하여 성능 최적화
  - **관심사 분리**: `FileData`와 `extractor.ExtractedFile`을 분리하여 포맷터 독립성 유지

  ## 🧪 테스트 결과 (Testing)

  - [x] **유닛 테스트**: `go test ./pkg/formatter/...` 통과 (10 tests)
  - [x] **빌드 테스트**: `go build ./...` 성공
  - [x] **코드 품질**: `go vet`, `gofmt` 검증 완료

  ```bash
  go test ./pkg/formatter/... -v
  # PASS: 10 tests
```