### PR TITLE
feat: Packager 구현 (Scanner → Extractor → Formatter 통합)

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,0 +1,179 @@
+// Package context provides global configuration and packaging logic for brfit.
+package context
+
+import (
+	"github.com/indigo-net/Brf.it/pkg/extractor"
+	"github.com/indigo-net/Brf.it/pkg/formatter"
+	"github.com/indigo-net/Brf.it/pkg/scanner"
+)
+
+// Options contains CLI options for packaging.
+type Options struct {
+	// Path is the target path to scan.
+	Path string
+
+	// Format is the output format ("xml" or "md").
+	Format string
+
+	// Output is the output file path (empty = stdout).
+	Output string
+
+	// IgnoreFile is the custom ignore file path.
+	IgnoreFile string
+
+	// IncludeHidden determines whether to include hidden files.
+	IncludeHidden bool
+
+	// IncludeTree determines whether to include directory tree.
+	IncludeTree bool
+
+	// IncludePrivate determines whether to include private symbols.
+	IncludePrivate bool
+
+	// MaxFileSize is the maximum file size in bytes.
+	MaxFileSize int64
+}
+
+// DefaultOptions returns Options with sensible defaults.
+func DefaultOptions() *Options {
+	return &Options{
+		Format:        "xml",
+		IgnoreFile:    ".gitignore",
+		IncludeTree:   true,
+		IncludeHidden: false,
+		MaxFileSize:   512000, // 500KB
+	}
+}
+
+// Result contains the final packaged output.
+type Result struct {
+	// Content is the formatted output bytes.
+	Content []byte
+
+	// TotalSignatures is the total number of signatures.
+	TotalSignatures int
+
+	// TotalFiles is the number of processed files.
+	TotalFiles int
+
+	// TotalSize is the total size of processed files.
+	TotalSize int64
+}
+
+// Packager orchestrates scanning, extraction, and formatting.
+type Packager struct {
+	scanner    scanner.Scanner
+	extractor  extractor.Extractor
+	formatters map[string]formatter.Formatter
+}
+
+// NewPackager creates a new Packager with the given dependencies.
+func NewPackager(
+	s scanner.Scanner,
+	e extractor.Extractor,
+	f map[string]formatter.Formatter,
+) *Packager {
+	return &Packager{
+		scanner:    s,
+		extractor:  e,
+		formatters: f,
+	}
+}
+
+// Package processes files and returns formatted output.
+func (p *Packager) Package(opts *Options) (*Result, error) {
+	if opts == nil {
+		opts = DefaultOptions()
+	}
+
+	// 1. Scan files
+	scanResult, err := p.scanner.Scan()
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Extract signatures
+	extractOpts := &extractor.ExtractOptions{
+		IncludePrivate: opts.IncludePrivate,
+	}
+	extractResult, err := p.extractor.Extract(scanResult, extractOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Build directory tree
+	var treeStr string
+	if opts.IncludeTree && len(scanResult.Files) > 0 {
+		paths := make([]string, len(scanResult.Files))
+		for i, f := range scanResult.Files {
+			paths[i] = f.Path
+		}
+		treeStr = BuildTree(opts.Path, paths)
+	}
+
+	// 4. Convert ExtractedFile to FileData
+	files := make([]formatter.FileData, len(extractResult.Files))
+	for i, ef := range extractResult.Files {
+		files[i] = formatter.FileData{
+			Path:       ef.Path,
+			Language:   ef.Language,
+			Signatures: ef.Signatures,
+			Error:      ef.Error,
+		}
+	}
+
+	// 5. Create PackageData
+	packageData := &formatter.PackageData{
+		Tree:            treeStr,
+		Files:           files,
+		TotalSignatures: extractResult.TotalSignatures,
+		TotalSize:       extractResult.TotalSize,
+	}
+
+	// 6. Get formatter (normalize format and fallback to xml)
+	format := normalizeFormat(opts.Format)
+	f, ok := p.formatters[format]
+	if !ok {
+		f = p.formatters["xml"]
+	}
+
+	// 7. Format output
+	content, err := f.Format(packageData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Content:         content,
+		TotalSignatures: extractResult.TotalSignatures,
+		TotalFiles:      len(extractResult.Files),
+		TotalSize:       extractResult.TotalSize,
+	}, nil
+}
+
+// NewDefaultPackager creates a Packager with default dependencies.
+func NewDefaultPackager(scanOpts *scanner.ScanOptions) (*Packager, error) {
+	s, err := scanner.NewFileScanner(scanOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	e := extractor.NewDefaultFileExtractor()
+
+	formatters := map[string]formatter.Formatter{
+		"xml":      formatter.NewXMLFormatter(),
+		"markdown": formatter.NewMarkdownFormatter(),
+	}
+
+	return NewPackager(s, e, formatters), nil
+}
+
+// normalizeFormat converts CLI format flag to formatter key.
+func normalizeFormat(format string) string {
+	switch format {
+	case "md":
+		return "markdown"
+	default:
+		return format
+	}
+}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -1,0 +1,321 @@
+package context
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/extractor"
+	"github.com/indigo-net/Brf.it/pkg/formatter"
+	"github.com/indigo-net/Brf.it/pkg/parser"
+	"github.com/indigo-net/Brf.it/pkg/scanner"
+)
+
+// mockScanner implements scanner.Scanner for testing
+type mockScanner struct {
+	result *scanner.ScanResult
+	err    error
+}
+
+func (m *mockScanner) Scan() (*scanner.ScanResult, error) {
+	return m.result, m.err
+}
+
+// mockExtractor implements extractor.Extractor for testing
+type mockExtractor struct {
+	result *extractor.ExtractResult
+	err    error
+}
+
+func (m *mockExtractor) Extract(_ *scanner.ScanResult, _ *extractor.ExtractOptions) (*extractor.ExtractResult, error) {
+	return m.result, m.err
+}
+
+func TestPackagerPackage(t *testing.T) {
+	mockScan := &mockScanner{
+		result: &scanner.ScanResult{
+			Files: []scanner.FileEntry{
+				{Path: "pkg/test.go", Language: "go", Size: 100},
+			},
+			TotalSize: 100,
+		},
+	}
+
+	mockExt := &mockExtractor{
+		result: &extractor.ExtractResult{
+			Files: []extractor.ExtractedFile{
+				{
+					Path:     "pkg/test.go",
+					Language: "go",
+					Signatures: []parser.Signature{
+						{
+							Name:     "Add",
+							Kind:     "function",
+							Text:     "func Add(a, b int) int",
+							Line:     5,
+							Language: "go",
+							Exported: true,
+						},
+					},
+					Size: 100,
+				},
+			},
+			TotalSignatures: 1,
+			TotalSize:       100,
+		},
+	}
+
+	formatters := map[string]formatter.Formatter{
+		"xml":      formatter.NewXMLFormatter(),
+		"markdown": formatter.NewMarkdownFormatter(),
+	}
+
+	p := NewPackager(mockScan, mockExt, formatters)
+
+	result, err := p.Package(&Options{
+		Path:        ".",
+		Format:      "xml",
+		IncludeTree: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.TotalSignatures != 1 {
+		t.Errorf("expected 1 signature, got %d", result.TotalSignatures)
+	}
+
+	if result.TotalFiles != 1 {
+		t.Errorf("expected 1 file, got %d", result.TotalFiles)
+	}
+
+	if !strings.Contains(string(result.Content), "<brfit>") {
+		t.Error("expected XML output to contain <brfit>")
+	}
+}
+
+func TestPackagerPackageMarkdown(t *testing.T) {
+	mockScan := &mockScanner{
+		result: &scanner.ScanResult{
+			Files: []scanner.FileEntry{
+				{Path: "test.go"},
+			},
+		},
+	}
+
+	mockExt := &mockExtractor{
+		result: &extractor.ExtractResult{
+			Files: []extractor.ExtractedFile{
+				{
+					Path:     "test.go",
+					Language: "go",
+					Signatures: []parser.Signature{
+						{Text: "func Test()", Language: "go"},
+					},
+				},
+			},
+			TotalSignatures: 1,
+		},
+	}
+
+	formatters := map[string]formatter.Formatter{
+		"xml":      formatter.NewXMLFormatter(),
+		"markdown": formatter.NewMarkdownFormatter(),
+	}
+
+	p := NewPackager(mockScan, mockExt, formatters)
+
+	// Test with "md" - should be normalized to "markdown"
+	result, err := p.Package(&Options{
+		Path:        ".",
+		Format:      "md",
+		IncludeTree: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(result.Content), "# Brf.it Output") {
+		t.Error("expected markdown header")
+	}
+}
+
+func TestPackagerPackageMarkdownFull(t *testing.T) {
+	mockScan := &mockScanner{
+		result: &scanner.ScanResult{
+			Files: []scanner.FileEntry{
+				{Path: "test.go"},
+			},
+		},
+	}
+
+	mockExt := &mockExtractor{
+		result: &extractor.ExtractResult{
+			Files: []extractor.ExtractedFile{
+				{
+					Path:       "test.go",
+					Language:   "go",
+					Signatures: []parser.Signature{{Text: "func Test()", Language: "go"}},
+				},
+			},
+			TotalSignatures: 1,
+		},
+	}
+
+	formatters := map[string]formatter.Formatter{
+		"xml":      formatter.NewXMLFormatter(),
+		"markdown": formatter.NewMarkdownFormatter(),
+	}
+
+	p := NewPackager(mockScan, mockExt, formatters)
+
+	// Test with "markdown" directly
+	result, err := p.Package(&Options{
+		Path:        ".",
+		Format:      "markdown",
+		IncludeTree: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(result.Content), "# Brf.it Output") {
+		t.Error("expected markdown header")
+	}
+}
+
+func TestPackagerUnknownFormat(t *testing.T) {
+	mockScan := &mockScanner{
+		result: &scanner.ScanResult{},
+	}
+
+	mockExt := &mockExtractor{
+		result: &extractor.ExtractResult{},
+	}
+
+	formatters := map[string]formatter.Formatter{
+		"xml": formatter.NewXMLFormatter(),
+	}
+
+	p := NewPackager(mockScan, mockExt, formatters)
+
+	result, err := p.Package(&Options{
+		Format: "unknown",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should fallback to xml
+	if !strings.Contains(string(result.Content), "<?xml") {
+		t.Error("expected fallback to XML format")
+	}
+}
+
+func TestBuildTree(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		paths    []string
+		contains string
+	}{
+		{
+			name:     "empty paths",
+			root:     ".",
+			paths:    []string{},
+			contains: "",
+		},
+		{
+			name:     "single file",
+			root:     ".",
+			paths:    []string{"main.go"},
+			contains: "main.go",
+		},
+		{
+			name:     "nested structure",
+			root:     ".",
+			paths:    []string{"pkg/scanner/scanner.go", "pkg/parser/parser.go"},
+			contains: "pkg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildTree(tt.root, tt.paths)
+			if tt.contains == "" {
+				if result != "" {
+					t.Errorf("expected empty string, got %q", result)
+				}
+			} else {
+				if !strings.Contains(result, tt.contains) {
+					t.Errorf("expected tree to contain %q, got %q", tt.contains, result)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTreeStructure(t *testing.T) {
+	paths := []string{
+		"pkg/scanner/scanner.go",
+		"pkg/parser/parser.go",
+	}
+
+	result := BuildTree(".", paths)
+
+	// Should contain pkg directory
+	if !strings.Contains(result, "pkg") {
+		t.Error("expected 'pkg' in tree")
+	}
+
+	// Should contain scanner.go
+	if !strings.Contains(result, "scanner.go") {
+		t.Error("expected 'scanner.go' in tree")
+	}
+
+	// Should contain parser.go
+	if !strings.Contains(result, "parser.go") {
+		t.Error("expected 'parser.go' in tree")
+	}
+
+	// Should use tree connectors
+	if !strings.Contains(result, "├──") && !strings.Contains(result, "└──") {
+		t.Error("expected tree connectors in output")
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+
+	if opts.Format != "xml" {
+		t.Errorf("expected default format 'xml', got %q", opts.Format)
+	}
+
+	if opts.MaxFileSize != 512000 {
+		t.Errorf("expected MaxFileSize 512000, got %d", opts.MaxFileSize)
+	}
+
+	if !opts.IncludeTree {
+		t.Error("expected IncludeTree to be true by default")
+	}
+}
+
+func TestNormalizeFormat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"xml", "xml"},
+		{"md", "markdown"},
+		{"markdown", "markdown"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeFormat(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeFormat(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/context/tree.go
+++ b/internal/context/tree.go
@@ -1,0 +1,86 @@
+package context
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// treeNode represents a node in the directory tree.
+type treeNode struct {
+	children map[string]*treeNode
+}
+
+// BuildTree generates a directory tree string from file paths.
+// The root parameter is used to calculate relative paths.
+func BuildTree(root string, paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+
+	rootNode := &treeNode{children: make(map[string]*treeNode)}
+
+	// Insert all paths into the tree
+	for _, path := range paths {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+
+		parts := strings.Split(rel, string(filepath.Separator))
+		current := rootNode
+
+		for _, part := range parts {
+			if _, exists := current.children[part]; !exists {
+				current.children[part] = &treeNode{
+					children: make(map[string]*treeNode),
+				}
+			}
+			current = current.children[part]
+		}
+	}
+
+	// Build the output string (root level has no prefix)
+	var buf strings.Builder
+	renderNode(&buf, rootNode, "", true)
+	return strings.TrimSuffix(buf.String(), "\n")
+}
+
+// renderNode recursively renders the tree structure.
+// isRoot indicates whether this is the root level (no connectors).
+func renderNode(buf *strings.Builder, n *treeNode, prefix string, isRoot bool) {
+	// Get sorted keys for consistent output
+	keys := make([]string, 0, len(n.children))
+	for k := range n.children {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i, key := range keys {
+		child := n.children[key]
+		isLast := i == len(keys)-1
+
+		if isRoot {
+			// Root level: no prefix, no connector
+			buf.WriteString(key + "\n")
+		} else {
+			// Child levels: with prefix and connector
+			connector := "├── "
+			if isLast {
+				connector = "└── "
+			}
+			buf.WriteString(prefix + connector + key + "\n")
+		}
+
+		// Render children with updated prefix
+		var newPrefix string
+		if isRoot {
+			newPrefix = ""
+		} else if isLast {
+			newPrefix = prefix + "    "
+		} else {
+			newPrefix = prefix + "│   "
+		}
+		renderNode(buf, child, newPrefix, false)
+	}
+}


### PR DESCRIPTION
  ## 🚀 개요 (Overview)

  - **기능**: Scanner → Extractor → Formatter 파이프라인을 통합하여 최종 출력을 생성하는 Packager 구현

  ## 🛠️ 작업 내용 (Changes)

  - [x] `internal/context/context.go` - Options, Result, Packager 타입 정의
  - [x] `internal/context/tree.go` - BuildTree 함수로 디렉토리 트리 생성
  - [x] `internal/context/context.go` - Package 메서드로 전체 파이프라인 구현
  - [x] `internal/context/context_test.go` - 8개 단위 테스트 작성

  ## 🏗️ 아키텍처/설계 결정 (Architectural Decisions)

  - **internal/context에 배치**: MASTER_PLAN의 구조를 따라 외부 노출이 불필요한 내부 로직을 internal에 배치
  - **인터페이스 의존**: Scanner, Extractor, Formatter 인터페이스에 의존하여 mock 주입이 용이하도록 설계
  - **Format 정규화**: CLI의 `-f md` 옵션을 `normalizeFormat()`로 `"markdown"`으로 변환하여 포맷터와 매핑
  - **트리 생성**: 루트 레벨은 커넥터 없이 시작, 하위 레벨부터 `├──`/`└──` 사용

  ## 🧪 테스트 결과 (Testing)

  - [x] **유닛 테스트**: `go test ./...` 9개 패키지 모두 통과
  - [x] **빌드 테스트**: `go build ./...` 성공

  ```bash
  go test ./internal/context/... -v
  # 8 tests passed

  go test ./...
  # ok  github.com/indigo-net/Brf.it/internal/context  0.473s
  # ... (9 packages total)
```