### PR TITLE
feat: CLI 통합 및 전체 파이프라인 완성 (Phase 10)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ package config
 import (
 	"errors"
 	"fmt"
+
+	pkgcontext "github.com/indigo-net/Brf.it/internal/context"
 )
 
 // Config holds all configuration options for the brfit CLI.
@@ -58,9 +60,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid mode '%s': only 'sig' mode is supported", c.Mode)
 	}
 
-	// Validate format
-	if c.Format != "xml" && c.Format != "md" {
-		return fmt.Errorf("invalid format '%s': must be 'xml' or 'md'", c.Format)
+	// Validate format (accept "xml", "md", "markdown")
+	if c.Format != "xml" && c.Format != "md" && c.Format != "markdown" {
+		return fmt.Errorf("invalid format '%s': must be 'xml', 'md', or 'markdown'", c.Format)
 	}
 
 	// Validate max file size
@@ -79,5 +81,19 @@ func (c *Config) SupportedExtensions() map[string]string {
 		".tsx": "typescript",
 		".js":  "javascript",
 		".jsx": "javascript",
+	}
+}
+
+// ToOptions converts Config to packager Options.
+func (c *Config) ToOptions() *pkgcontext.Options {
+	return &pkgcontext.Options{
+		Path:           c.Path,
+		Format:         c.Format,
+		Output:         c.Output,
+		IgnoreFile:     c.IgnoreFile,
+		IncludeHidden:  c.IncludeHidden,
+		IncludeTree:    !c.NoTree,
+		IncludePrivate: false, // Future: add --include-private flag
+		MaxFileSize:    c.MaxFileSize,
 	}
 }


### PR DESCRIPTION
## 🚀 개요 (Overview)

- **기능**: CLI에서 Packager를 통합하여 Scanner → Extractor → Formatter 전체 파이프라인을 실행하는 end-to-end CLI 도구 완성

## 🛠️ 작업 내용 (Changes)

- [x] `Config.ToOptions()` 메서드 추가 (Config → context.Options 변환)
- [x] `Config.Format` 검증에 "markdown" 포맷 허용
- [x] `root.go`에 Packager 통합으로 전체 파이프라인 실행
- [x] `os.Stdout.Write()`로 효율적인 []byte 직접 출력
- [x] 파일 출력 시 `os.MkdirAll`로 디렉토리 자동 생성
- [x] stderr에 Files/Signatures/Tokens 요약 표시 (stdout 오염 방지)
- [x] Treesitter parser blank import로 Go/TypeScript 파서 자동 등록
- [x] CLI 통합 테스트 추가 (XML/Markdown 출력, 에러 처리)

## 🏗️ 아키텍처/설계 결정 (Architectural Decisions)

- **Config vs Options 분리**: Config는 CLI 플래그용, Options는 Packager용으로 관심사 분리. `ToOptions()` 메서드로 변환.
- **stderr vs stdout**: Token count와 요약은 stderr로 출력하여 파이프라인 호환성 유지.
- **[]byte 직접 출력**: string 변환 없이 `os.Stdout.Write()` 사용하여 효율성 확보.
- **Parser 자동 등록**: blank import로 treesitter parser의 init() 함수가 실행되어 Go/TypeScript 파서가 자동 등록됨.

## 🧪 테스트 결과 (Testing)

- [x] **유닛 테스트**: `go test ./...` 통과
- [x] **빌드 테스트**: `go build ./...` 성공
- [x] **수동 테스트**:

```bash
# XML 출력
$ go run ./cmd/brfit . -f xml
<?xml version="1.0" encoding="UTF-8"?>
<brfit>
  <metadata>
    <tree>...</tree>
    ...
  </metadata>
  <files>
    <file path="internal/config/config.go" language="go">
      <signature>func (c *Config) ToOptions() *pkgcontext.Options</signature>
    </file>
  </files>
</brfit>
Files: 26, Signatures: 158, Tokens: 39972

# Markdown 출력
$ go run ./cmd/brfit . -f md
# Brf.it Output
...

# 파일 출력 (디렉토리 자동 생성)
$ go run ./cmd/brfit . -o subdir/output.xml
Files: 26, Signatures: 158, Tokens: 39972