### PR TITLE
feat: npm 배포를 위한 패키지 구조 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,20 @@ Brf.it은 이 문제를 해결합니다.
 
 ### 설치
 
+#### npm (권장)
+
 ```bash
-# 소스에서 빌드
+# npx로 바로 실행
+npx brfit .
+
+# 또는 전역 설치
+npm install -g brfit
+brfit .
+```
+
+#### 소스에서 빌드
+
+```bash
 git clone https://github.com/indigo-net/Brf.it.git
 cd Brf.it
 go build -o bin/brfit ./cmd/brfit
@@ -69,37 +81,37 @@ brfit [path] [options]
 
 ```bash
 # 기본 사용법 (XML, stdout)
-brfit .
+npx brfit .
 
 # Markdown 포맷으로 출력
-brfit . -f md
+npx brfit . -f md
 
 # 결과를 파일로 저장
-brfit . -o output.xml
+npx brfit . -o output.xml
 
 # 하위 디렉토리에 저장 (자동 생성)
-brfit . -o build/output/result.xml
+npx brfit . -o build/output/result.xml
 
 # 토큰 카운트 없이
-brfit . --no-tokens
+npx brfit . --no-tokens
 
 # 트리 없이 시그니처만
-brfit . --no-tree
+npx brfit . --no-tree
 
 # 숨김 파일 포함
-brfit . --include-hidden
+npx brfit . --include-hidden
 
 # 커스텀 ignore 파일
-brfit . -i .brfitignore
+npx brfit . -i .brfitignore
 
 # 최대 파일 크기 설정
-brfit . --max-size 1000000
+npx brfit . --max-size 1000000
 
 # 버전 확인
-brfit --version
+npx brfit --version
 
 # 도움말
-brfit --help
+npx brfit --help
 ```
 
 ### 출력 예시
@@ -194,8 +206,20 @@ Brf.it solves this problem.
 
 ### Installation
 
+#### npm (Recommended)
+
 ```bash
-# Build from source
+# Run directly with npx
+npx brfit .
+
+# Or install globally
+npm install -g brfit
+brfit .
+```
+
+#### Build from Source
+
+```bash
 git clone https://github.com/indigo-net/Brf.it.git
 cd Brf.it
 go build -o bin/brfit ./cmd/brfit
@@ -225,37 +249,37 @@ brfit [path] [options]
 
 ```bash
 # Basic usage (XML, stdout)
-brfit .
+npx brfit .
 
 # Output in Markdown format
-brfit . -f md
+npx brfit . -f md
 
 # Save output to file
-brfit . -o output.xml
+npx brfit . -o output.xml
 
 # Save to subdirectory (auto-created)
-brfit . -o build/output/result.xml
+npx brfit . -o build/output/result.xml
 
 # Without token count
-brfit . --no-tokens
+npx brfit . --no-tokens
 
 # Skip directory tree
-brfit . --no-tree
+npx brfit . --no-tree
 
 # Include hidden files
-brfit . --include-hidden
+npx brfit . --include-hidden
 
 # Custom ignore file
-brfit . -i .brfitignore
+npx brfit . -i .brfitignore
 
 # Set max file size
-brfit . --max-size 1000000
+npx brfit . --max-size 1000000
 
 # Show version
-brfit --version
+npx brfit --version
 
 # Show help
-brfit --help
+npx brfit --help
 ```
 
 ### Output Examples

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,2 @@
+# Downloaded binaries (installed via postinstall)
+bin/

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+const platform = process.platform;
+const arch = process.arch;
+
+// 플랫폼별 바이너리 경로 결정
+let binaryName;
+if (platform === 'win32') {
+  binaryName = 'brfit-windows-amd64.exe';
+} else if (platform === 'darwin') {
+  binaryName = arch === 'arm64' ? 'brfit-darwin-arm64' : 'brfit-darwin-amd64';
+} else if (platform === 'linux') {
+  binaryName = arch === 'arm64' ? 'brfit-linux-arm64' : 'brfit-linux-amd64';
+} else {
+  console.error(`Unsupported platform: ${platform}-${arch}`);
+  process.exit(1);
+}
+
+const binaryPath = path.join(__dirname, 'bin', binaryName);
+
+// 바이너리 실행
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: 'inherit'
+});
+
+child.on('exit', (code) => {
+  process.exit(code || 0);
+});

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,65 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const packageJson = require('./package.json');
+const version = packageJson.version;
+
+const platform = process.platform;
+const arch = process.arch;
+
+// 플랫폼별 파일명
+let binaryName;
+if (platform === 'win32') {
+  binaryName = 'brfit-windows-amd64.exe';
+} else if (platform === 'darwin') {
+  binaryName = arch === 'arm64' ? 'brfit-darwin-arm64' : 'brfit-darwin-amd64';
+} else if (platform === 'linux') {
+  binaryName = arch === 'arm64' ? 'brfit-linux-arm64' : 'brfit-linux-amd64';
+} else {
+  console.error(`Unsupported platform: ${platform}-${arch}`);
+  process.exit(1);
+}
+
+const downloadUrl = `https://github.com/indigo-net/Brf.it/releases/download/v${version}/${binaryName}`;
+const binDir = path.join(__dirname, 'bin');
+const outputPath = path.join(binDir, binaryName);
+
+// bin 디렉토리 생성
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+
+console.log(`Downloading brfit v${version} for ${platform}-${arch}...`);
+
+const file = fs.createWriteStream(outputPath);
+
+https.get(downloadUrl, (response) => {
+  if (response.statusCode === 302 || response.statusCode === 301) {
+    // 리다이렉트 처리
+    https.get(response.headers.location, (redirectResponse) => {
+      redirectResponse.pipe(file);
+    }).on('error', (err) => {
+      console.error('Download failed:', err.message);
+      process.exit(1);
+    });
+  } else if (response.statusCode === 200) {
+    response.pipe(file);
+  } else {
+    console.error(`Download failed: HTTP ${response.statusCode}`);
+    console.error('Make sure the release exists at:', downloadUrl);
+    process.exit(1);
+  }
+}).on('error', (err) => {
+  console.error('Download failed:', err.message);
+  process.exit(1);
+});
+
+file.on('finish', () => {
+  file.close();
+  // 실행 권한 부여 (Unix)
+  if (platform !== 'win32') {
+    fs.chmodSync(outputPath, '755');
+  }
+  console.log('brfit installed successfully!');
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "brfit",
+  "version": "0.1.0",
+  "description": "Brief your code for AI assistants",
+  "bin": {
+    "brfit": "./index.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/indigo-net/Brf.it.git",
+    "directory": "npm"
+  },
+  "keywords": ["ai", "cli", "code", "signature", "tree-sitter"],
+  "author": "indigo-net",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/indigo-net/Brf.it/issues"
+  },
+  "homepage": "https://github.com/indigo-net/Brf.it#readme",
+  "engines": {
+    "node": ">=16"
+  },
+  "os": ["darwin", "linux", "win32"],
+  "cpu": ["x64", "arm64"]
+}


### PR DESCRIPTION
## 🚀 개요 (Overview)

- **기능**: `npx brfit` 명령어로 누구나 쉽게 사용할 수 있도록 npm 배포 구조 추가

## 🛠️ 작업 내용 (Changes)

- [x] `npm/package.json` - 패키지 매니페스트 (bin 바인딩 포함)
- [x] `npm/index.js` - 플랫폼별 바이너리 실행 진입점
- [x] `npm/install.js` - postinstall 스크립트 (GitHub Releases에서 바이너리 다운로드)
- [x] `npm/.gitignore` - 다운로드된 바이너리 무시
- [x] `README.md` - npm 설치 방법 추가 (한국어/영어)

## 🏗️ 아키텍처/설계 결정 (Architectural Decisions)

- **바이너리 번들링 방식 선택**: npm 패키지에 바이너리를 직접 포함하지 않고, postinstall 시점에 GitHub Releases에서 다운로드
  - 이유: 패키지 크기 최소화, 플랫폼별 바이너리만 다운로드
- **플랫폼 지원**: darwin-amd64, darwin-arm64, linux-amd64, linux-arm64, windows-amd64

## 🧪 테스트 결과 (Testing)

- [x] **유닛 테스트**: `go test ./...` 통과 (10 packages)
- [x] **빌드 테스트**: `go build` 성공
- [x] **수동 테스트**: `npm link`로 로컬 테스트 완료

```bash
# 로컬 테스트
cd npm && npm link --ignore-scripts
mkdir -p bin && go build -o bin/brfit-darwin-arm64 ./cmd/brfit
brfit --version  # → brfit version 0.1.0