### PR TITLE
refactor: 테스트 코드 sitter.Query 리소스 해제 일괄 정리

### DIFF
--- a/pkg/parser/treesitter/languages/c_test.go
+++ b/pkg/parser/treesitter/languages/c_test.go
@@ -26,10 +26,11 @@ func TestCQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_c.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestCQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/cpp_test.go
+++ b/pkg/parser/treesitter/languages/cpp_test.go
@@ -26,10 +26,11 @@ func TestCppQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_cpp.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestCppQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/go_test.go
+++ b/pkg/parser/treesitter/languages/go_test.go
@@ -26,10 +26,11 @@ func TestGoQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_go.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestGoQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/java_test.go
+++ b/pkg/parser/treesitter/languages/java_test.go
@@ -26,10 +26,11 @@ func TestJavaQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_java.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestJavaQueryKindMapping(t *testing.T) {

--- a/pkg/parser/treesitter/languages/kotlin_test.go
+++ b/pkg/parser/treesitter/languages/kotlin_test.go
@@ -61,10 +61,11 @@ func TestKotlinQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_kotlin.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestKotlinQueryImportPattern(t *testing.T) {
@@ -77,10 +78,11 @@ func TestKotlinQueryImportPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_kotlin.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid import query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestKotlinQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/python_test.go
+++ b/pkg/parser/treesitter/languages/python_test.go
@@ -26,10 +26,11 @@ func TestPythonQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_python.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestPythonQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/rust_test.go
+++ b/pkg/parser/treesitter/languages/rust_test.go
@@ -26,10 +26,11 @@ func TestRustQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_rust.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestRustQueryImportPattern(t *testing.T) {
@@ -42,10 +43,11 @@ func TestRustQueryImportPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_rust.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid import query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestRustQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/swift_test.go
+++ b/pkg/parser/treesitter/languages/swift_test.go
@@ -26,10 +26,11 @@ func TestSwiftQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_swift.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestSwiftQueryImportPattern(t *testing.T) {
@@ -42,10 +43,11 @@ func TestSwiftQueryImportPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_swift.Language())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid import query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestSwiftQueryExtractFunction(t *testing.T) {

--- a/pkg/parser/treesitter/languages/typescript_test.go
+++ b/pkg/parser/treesitter/languages/typescript_test.go
@@ -26,10 +26,11 @@ func TestTypeScriptQueryPattern(t *testing.T) {
 
 	// Compile query to verify syntax
 	lang := sitter.NewLanguage(tree_sitter_typescript.LanguageTypescript())
-	_, err := sitter.NewQuery(lang, string(pattern))
+	q, err := sitter.NewQuery(lang, string(pattern))
 	if err != nil {
 		t.Fatalf("invalid query pattern: %v", err)
 	}
+	defer q.Close()
 }
 
 func TestTypeScriptQueryExtractFunction(t *testing.T) {


### PR DESCRIPTION
## Summary

- `sitter.NewQuery()` 반환값을 `_`로 버리고 `Close()`를 호출하지 않는 리소스 누수 패턴 12건 일괄 수정
- 9개 테스트 파일에서 `q, err := sitter.NewQuery(...)` + `defer q.Close()` 패턴으로 통일

## 대상 파일 (9개, 12건)

- `c_test.go`, `cpp_test.go`, `go_test.go`, `java_test.go`, `python_test.go`, `typescript_test.go` (각 1건)
- `rust_test.go`, `swift_test.go`, `kotlin_test.go` (각 2건)

## Test plan

- [x] `go test ./pkg/parser/treesitter/languages/...` 전체 통과
- [x] `go vet ./pkg/parser/treesitter/languages/...` 클린

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)