### PR TITLE
fix: .gitignore 로드 실패 시 경고 출력

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -2,6 +2,7 @@
 package scanner
 
 import (
+	"errors"
 	"io/fs"
 	"log"
 	"os"
@@ -99,10 +100,11 @@ type Scanner interface {
 
 // FileScanner implements Scanner for file system traversal.
 type FileScanner struct {
-	opts       *ScanOptions
-	ignorer    *ignore.GitIgnore
-	ignorerErr error
-	logger     *log.Logger
+	opts             *ScanOptions
+	ignorer          *ignore.GitIgnore
+	ignorerErr       error
+	ignorerErrWarned bool
+	logger           *log.Logger
 }
 
 // NewFileScanner creates a new FileScanner with the given options.
@@ -121,8 +123,11 @@ func NewFileScanner(opts *ScanOptions) (*FileScanner, error) {
 	if opts.IgnoreFile != "" {
 		ignorer, err := ignore.CompileIgnoreFile(opts.IgnoreFile)
 		if err != nil {
-			// Store error but don't fail - gitignore is optional
-			scanner.ignorerErr = err
+			// Default .gitignore not found is normal; only store error for
+			// user-specified ignore files or non-file-not-found errors.
+			if !(errors.Is(err, os.ErrNotExist) && opts.IgnoreFile == ".gitignore") {
+				scanner.ignorerErr = err
+			}
 		} else {
 			scanner.ignorer = ignorer
 		}
@@ -136,9 +141,10 @@ func NewFileScanner(opts *ScanOptions) (*FileScanner, error) {
 func (s *FileScanner) Scan() (*ScanResult, error) {
 	result := &ScanResult{}
 
-	// Warn if gitignore loading failed
-	if s.ignorerErr != nil {
-		s.logger.Printf("WARN: failed to load ignore file: %v\n", s.ignorerErr)
+	// Warn once if gitignore loading failed
+	if s.ignorerErr != nil && !s.ignorerErrWarned {
+		s.logger.Printf("WARN: failed to load ignore file: %v", s.ignorerErr)
+		s.ignorerErrWarned = true
 	}
 
 	// Check if root path is a file

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -406,26 +406,73 @@ func TestScanGitignoreLoadFailureWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	opts := DefaultScanOptions()
-	opts.RootPath = tmpDir
-	opts.IgnoreFile = filepath.Join(tmpDir, "nonexistent-gitignore")
+	t.Run("user-specified ignore file missing warns", func(t *testing.T) {
+		opts := DefaultScanOptions()
+		opts.RootPath = tmpDir
+		opts.IgnoreFile = filepath.Join(tmpDir, "nonexistent-gitignore")
 
-	sc, err := NewFileScanner(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
+		sc, err := NewFileScanner(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	var buf bytes.Buffer
-	sc.logger = log.New(&buf, "[brfit] ", 0)
+		var buf bytes.Buffer
+		sc.logger = log.New(&buf, "[brfit] ", 0)
 
-	_, err = sc.Scan()
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err = sc.Scan()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if !strings.Contains(buf.String(), "WARN") || !strings.Contains(buf.String(), "ignore file") {
-		t.Errorf("expected warning about ignore file failure, got: %s", buf.String())
-	}
+		if !strings.Contains(buf.String(), "WARN") || !strings.Contains(buf.String(), "ignore file") {
+			t.Errorf("expected warning about ignore file failure, got: %q", buf.String())
+		}
+	})
+
+	t.Run("default gitignore missing does not warn", func(t *testing.T) {
+		opts := DefaultScanOptions()
+		opts.RootPath = tmpDir
+		// IgnoreFile defaults to ".gitignore" which doesn't exist in tmpDir
+
+		sc, err := NewFileScanner(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		sc.logger = log.New(&buf, "[brfit] ", 0)
+
+		_, err = sc.Scan()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if buf.Len() > 0 {
+			t.Errorf("expected no warning for default missing .gitignore, got: %q", buf.String())
+		}
+	})
+
+	t.Run("warning emitted only once on repeated Scan calls", func(t *testing.T) {
+		opts := DefaultScanOptions()
+		opts.RootPath = tmpDir
+		opts.IgnoreFile = filepath.Join(tmpDir, "nonexistent-gitignore")
+
+		sc, err := NewFileScanner(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		sc.logger = log.New(&buf, "[brfit] ", 0)
+
+		_, _ = sc.Scan()
+		_, _ = sc.Scan()
+
+		warnCount := strings.Count(buf.String(), "WARN")
+		if warnCount != 1 {
+			t.Errorf("expected exactly 1 warning, got %d: %q", warnCount, buf.String())
+		}
+	})
 }
 
 func TestScanNestedDirectories(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Scan()` 시작 시 gitignore 로드 실패(`ignorerErr`)가 있으면 stderr 경고 출력
- 기존 동작(gitignore 없이 계속 스캔)은 그대로 유지

Closes #65

## Test plan
- [x] `TestScanGitignoreLoadFailureWarning` — 존재하지 않는 ignore 파일로 경고 확인
- [x] `go test ./pkg/scanner/` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)