### PR TITLE
fix: WalkDir 에러 처리 개선 및 심볼릭 링크 건너뛰기

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -3,6 +3,7 @@ package scanner
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"log"
 	"os"
@@ -34,6 +35,9 @@ type ScanResult struct {
 
 	// SkippedCount is the number of files skipped (too large, unsupported, etc.).
 	SkippedCount int
+
+	// Warnings contains non-fatal issues encountered during scanning.
+	Warnings []string
 }
 
 // ScanOptions configures the scanning behavior.
@@ -167,7 +171,28 @@ func (s *FileScanner) Scan() (*ScanResult, error) {
 	// Directory - walk recursively using WalkDir (more efficient than Walk)
 	err = filepath.WalkDir(s.opts.RootPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// Skip files/directories we can't access
+			var warning string
+			switch {
+			case os.IsPermission(err):
+				warning = fmt.Sprintf("permission denied: %s", path)
+			case os.IsNotExist(err):
+				warning = fmt.Sprintf("file not found: %s", path)
+			default:
+				warning = fmt.Sprintf("skipping: %s: %v", path, err)
+			}
+			s.logger.Printf("WARN: %s\n", warning)
+			result.Warnings = append(result.Warnings, warning)
+			return nil
+		}
+
+		// Skip symlinks
+		if d.Type()&os.ModeSymlink != 0 {
+			warning := fmt.Sprintf("skipping symlink: %s", path)
+			s.logger.Printf("WARN: %s\n", warning)
+			result.Warnings = append(result.Warnings, warning)
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 
@@ -190,6 +215,9 @@ func (s *FileScanner) Scan() (*ScanResult, error) {
 		// Get file info for size check
 		info, err := d.Info()
 		if err != nil {
+			warning := fmt.Sprintf("skipping: %s: %v", path, err)
+			s.logger.Printf("WARN: %s\n", warning)
+			result.Warnings = append(result.Warnings, warning)
 			return nil
 		}
 

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -475,6 +475,115 @@ func TestScanGitignoreLoadFailureWarning(t *testing.T) {
 	})
 }
 
+func TestScanWalkDirPermissionDenied(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "brfit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	normalFile := filepath.Join(tmpDir, "normal.go")
+	if err := os.WriteFile(normalFile, []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	noAccessDir := filepath.Join(tmpDir, "noaccess")
+	if err := os.Mkdir(noAccessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	innerFile := filepath.Join(noAccessDir, "inner.go")
+	if err := os.WriteFile(innerFile, []byte("package inner\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(noAccessDir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(noAccessDir, 0755)
+
+	opts := DefaultScanOptions()
+	opts.RootPath = tmpDir
+
+	sc, err := NewFileScanner(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	sc.logger = log.New(&buf, "[brfit] ", 0)
+
+	result, err := sc.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Files) < 1 {
+		t.Error("expected at least 1 file")
+	}
+
+	hasWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "permission denied") {
+			hasWarning = true
+			break
+		}
+	}
+	if !hasWarning {
+		t.Errorf("expected permission denied warning in result.Warnings, got: %v", result.Warnings)
+	}
+}
+
+func TestScanSymlinkSkip(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "brfit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	normalFile := filepath.Join(tmpDir, "normal.go")
+	if err := os.WriteFile(normalFile, []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkFile := filepath.Join(tmpDir, "link.go")
+	if err := os.Symlink(normalFile, symlinkFile); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	opts := DefaultScanOptions()
+	opts.RootPath = tmpDir
+
+	sc, err := NewFileScanner(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	sc.logger = log.New(&buf, "[brfit] ", 0)
+
+	result, err := sc.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Files) != 1 {
+		t.Errorf("expected 1 file (symlink excluded), got %d", len(result.Files))
+		for _, f := range result.Files {
+			t.Logf("  - %s", f.Path)
+		}
+	}
+
+	hasSymlinkWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "symlink") {
+			hasSymlinkWarning = true
+			break
+		}
+	}
+	if !hasSymlinkWarning {
+		t.Errorf("expected symlink warning in result.Warnings, got: %v", result.Warnings)
+	}
+}
+
 func TestScanNestedDirectories(t *testing.T) {
 	// Create nested directory structure
 	tmpDir, err := os.MkdirTemp("", "brfit-test-*")


### PR DESCRIPTION
## Summary
- `ScanResult`에 `Warnings []string` 필드 추가
- WalkDir 에러를 `permission denied` / `file not found` / 기타로 분류하여 경고 기록
- `d.Info()` 에러도 동일 패턴 적용
- 심볼릭 링크 감지 시 건너뛰고 경고 기록

Closes #64
Closes #66

## Test plan
- [x] `TestScanWalkDirPermissionDenied` — 권한 없는 디렉토리 경고 확인
- [x] `TestScanSymlinkSkip` — 심볼릭 링크 건너뛰기 및 경고 확인
- [x] `go test ./pkg/scanner/` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)