### PR TITLE
fix: Tree-sitter 쿼리 에러 전파

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -96,12 +96,18 @@ func (p *TreeSitterParser) Parse(content string, opts *parser.Options) (result *
 	}
 
 	// Extract signatures
-	signatures := p.extractSignatures(tree.RootNode(), []byte(content), query, opts)
+	signatures, err := p.extractSignatures(tree.RootNode(), []byte(content), query, opts)
+	if err != nil {
+		return nil, fmt.Errorf("signature extraction failed: %w", err)
+	}
 
 	// Extract imports if requested
 	var imports []parser.ImportExport
 	if opts.IncludeImports {
-		imports = p.extractImports(tree.RootNode(), []byte(content), query, opts)
+		imports, err = p.extractImports(tree.RootNode(), []byte(content), query, opts)
+		if err != nil {
+			return nil, fmt.Errorf("import extraction failed: %w", err)
+		}
 	}
 
 	return &parser.ParseResult{
@@ -126,13 +132,13 @@ func (p *TreeSitterParser) extractSignatures(
 	content []byte,
 	langQuery LanguageQuery,
 	opts *parser.Options,
-) []parser.Signature {
+) ([]parser.Signature, error) {
 	var signatures []parser.Signature
 
 	// Create query
 	query, err := sitter.NewQuery(langQuery.Language(), string(langQuery.Query()))
 	if err != nil {
-		return signatures
+		return nil, fmt.Errorf("failed to create signature query for %s: %w", opts.Language, err)
 	}
 	defer query.Close()
 
@@ -273,7 +279,7 @@ func (p *TreeSitterParser) extractSignatures(
 		}
 	}
 
-	return signatures
+	return signatures, nil
 }
 
 // cleanComment removes comment markers from the text.
@@ -945,18 +951,18 @@ func (p *TreeSitterParser) extractImports(
 	content []byte,
 	langQuery LanguageQuery,
 	opts *parser.Options,
-) []parser.ImportExport {
+) ([]parser.ImportExport, error) {
 	var imports []parser.ImportExport
 
 	importQueryBytes := langQuery.ImportQuery()
 	if importQueryBytes == nil || len(importQueryBytes) == 0 {
-		return imports
+		return imports, nil
 	}
 
 	// Create query
 	query, err := sitter.NewQuery(langQuery.Language(), string(importQueryBytes))
 	if err != nil {
-		return imports
+		return nil, fmt.Errorf("failed to create import query for %s: %w", opts.Language, err)
 	}
 	defer query.Close()
 
@@ -1014,7 +1020,7 @@ func (p *TreeSitterParser) extractImports(
 		}
 	}
 
-	return imports
+	return imports, nil
 }
 
 // cleanImportPath removes quotes and normalizes import paths.


### PR DESCRIPTION
## Summary
- `extractSignatures()`와 `extractImports()` 반환 타입에 `error` 추가
- 쿼리 생성 실패 시 에러를 호출자(`Parse()`)까지 전파
- 기존의 silent failure(빈 결과 반환) 패턴 제거

Closes #63

## Test plan
- [x] `go test ./pkg/parser/treesitter/` 전체 통과 (기존 테스트로 정상 동작 검증)
- [x] `go vet ./...` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)