### PR TITLE
fix: TOCTOU 경합 조건 방어

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -127,6 +127,7 @@ func (p *Packager) Package(opts *Options) (*Result, error) {
 		IncludePrivate: opts.IncludePrivate,
 		IncludeBody:    opts.IncludeBody,
 		IncludeImports: opts.IncludeImports,
+		MaxFileSize:    opts.MaxFileSize,
 	}
 	extractResult, err := p.extractor.Extract(scanResult, extractOpts)
 	if err != nil {

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -58,6 +58,10 @@ type ExtractOptions struct {
 
 	// Concurrency is the number of concurrent workers (0 = sequential).
 	Concurrency int
+
+	// MaxFileSize is the maximum file size in bytes for TOCTOU re-check.
+	// If positive, file content size is verified after reading.
+	MaxFileSize int64
 }
 
 // Extractor defines the interface for signature extraction.
@@ -124,6 +128,13 @@ func (e *FileExtractor) extractFile(entry scanner.FileEntry, opts *ExtractOption
 	content, err := os.ReadFile(entry.Path)
 	if err != nil {
 		extracted.Error = fmt.Errorf("failed to read file: %w", err)
+		return extracted
+	}
+
+	// TOCTOU guard: re-check file size after reading
+	if opts.MaxFileSize > 0 && int64(len(content)) > opts.MaxFileSize {
+		extracted.Error = fmt.Errorf("file size changed since scan: %s (%d > %d)",
+			entry.Path, len(content), opts.MaxFileSize)
 		return extracted
 	}
 

--- a/pkg/extractor/extractor_test.go
+++ b/pkg/extractor/extractor_test.go
@@ -3,6 +3,7 @@ package extractor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/indigo-net/Brf.it/pkg/parser"
@@ -85,6 +86,78 @@ type Point struct {
 
 	if !foundAdd {
 		t.Error("expected to find 'Add' function signature")
+	}
+}
+
+func TestFileExtractorTOCTOUGuard(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "brfit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testFile := filepath.Join(tmpDir, "big.go")
+	bigContent := "package big\n" + strings.Repeat("// padding\n", 100)
+	if err := os.WriteFile(testFile, []byte(bigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	scanResult := &scanner.ScanResult{
+		Files: []scanner.FileEntry{
+			{Path: testFile, Language: "go", Size: 10},
+		},
+	}
+
+	extractor := NewDefaultFileExtractor()
+	opts := &ExtractOptions{
+		MaxFileSize: 50,
+	}
+
+	result, err := extractor.Extract(scanResult, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.ErrorCount != 1 {
+		t.Errorf("expected 1 error (TOCTOU size mismatch), got %d", result.ErrorCount)
+	}
+
+	if result.Files[0].Error == nil {
+		t.Error("expected error for file size mismatch")
+	} else if !strings.Contains(result.Files[0].Error.Error(), "file size changed") {
+		t.Errorf("expected 'file size changed' error, got: %v", result.Files[0].Error)
+	}
+}
+
+func TestFileExtractorTOCTOUGuardDisabled(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "brfit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testFile := filepath.Join(tmpDir, "test.go")
+	testCode := "package test\n\nfunc Foo() {}\n"
+	if err := os.WriteFile(testFile, []byte(testCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	scanResult := &scanner.ScanResult{
+		Files: []scanner.FileEntry{
+			{Path: testFile, Language: "go", Size: int64(len(testCode))},
+		},
+	}
+
+	extractor := NewDefaultFileExtractor()
+	opts := &ExtractOptions{MaxFileSize: 0}
+
+	result, err := extractor.Extract(scanResult, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.ErrorCount != 0 {
+		t.Errorf("expected 0 errors when TOCTOU disabled, got %d", result.ErrorCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ExtractOptions`에 `MaxFileSize` 필드 추가
- `extractFile()`에서 파일 읽기 후 실제 크기 재확인 (TOCTOU 방어)
- `context.go`에서 `MaxFileSize`를 `ExtractOptions`로 전달

Closes #67

## Test plan
- [x] `TestFileExtractorTOCTOUGuard` — 스캔 후 파일 크기 변경 시 에러 확인
- [x] `TestFileExtractorTOCTOUGuardDisabled` — MaxFileSize=0일 때 체크 비활성화 확인
- [x] `go test ./pkg/extractor/ ./internal/context/` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)