### PR TITLE
feat: version_tag 라벨 시스템 도입

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,6 +58,18 @@ body:
         Stack trace: ...
       render: shell
 
+  - type: dropdown
+    id: version_impact
+    attributes:
+      label: 🏷️ 버전 영향도 (Version Impact)
+      description: 이 버그 수정 시 예상되는 버전 변경
+      options:
+        - patch (버그 수정)
+        - minor (기능 개선 포함)
+        - major (Breaking change)
+    validations:
+      required: true
+
   - type: textarea
     id: additional
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -53,6 +53,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: version_impact
+    attributes:
+      label: 🏷️ 버전 영향도 (Version Impact)
+      description: 이 기능 추가 시 예상되는 버전 변경
+      options:
+        - minor (새 기능)
+        - major (Breaking change)
+        - patch (작은 개선)
+    validations:
+      required: true
+
   - type: textarea
     id: alternatives
     attributes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ git log --oneline origin/<branch> | head -3  # 리모트 확인
 모든 코드 변경 작업은 **worktree 격리 환경**에서 이슈 기반으로 진행합니다:
 
 1. **이슈 조회** (필수): `gh issue list --state open --search "키워드"`로 기존 이슈 확인 → 중복 발견 시 기존 이슈에 코멘트 추가, 새 이슈 생성 금지
-2. **이슈 생성**: 중복이 없을 때만 `gh issue create --assignee indigo-net --label "enhancement"`
+2. **이슈 생성**: 중복이 없을 때만 `gh issue create --assignee indigo-net --label "enhancement,version:minor"`
 3. **Worktree + 브랜치 생성**: `git worktree add -b feat/feature-name .worktrees/<name> main`으로 격리 환경과 브랜치를 동시에 생성
 4. **커밋**: `git commit -m "feat: 구현 내용 (#123)"` (이슈 번호 괄호로 참조)
 5. **PR 생성**: `gh pr create --assignee indigo-net` + `Closes #XXX` in body
@@ -319,6 +319,20 @@ git log --oneline origin/<branch> | head -3  # 리모트 확인
 **브랜치명 형식**: `{type}/{feature-name}` (예: `feat/github-workflow-setup`)
 
 **이슈/PR assignee**: 기본적으로 `indigo-net` 지정
+
+**version_tag 라벨 (필수)**: 모든 이슈는 다음 중 하나의 라벨이 필요합니다:
+- `version:major` - Breaking change (API 변경, 호환성 깨짐)
+- `version:minor` - 새 기능, 기능 개선
+- `version:patch` - 버그 수정, 문서 수정, 리팩토링
+
+이슈 생성 예시:
+```bash
+# 새 기능 (minor)
+gh issue create --assignee indigo-net --label "enhancement,version:minor"
+
+# 버그 수정 (patch)
+gh issue create --assignee indigo-net --label "bug,version:patch"
+```
 
 ### Worktree 작업 규칙
 


### PR DESCRIPTION
## Summary

GitHub 이슈에 `version:major`, `version:minor`, `version:patch` 라벨 시스템을 도입하여, 작업 완료 시 어떤 버전 업데이트가 필요한지 명확히 합니다.

### Changes
- ✨ GitHub 라벨 3개 생성 (`version:major`, `version:minor`, `version:patch`)
- 📝 Issue templates에 버전 영향도 필드 추가
- 📝 CLAUDE.md에 version_tag 라벨 규칙 추가
- 🏷️ 기존 30개 open 이슈에 적절한 version 라벨 추가

## Test plan

- [x] `gh label list`로 라벨 생성 확인
- [ ] GitHub에서 새 이슈 생성 시 템플릿 드롭다운 동작 확인
- [x] 기존 이슈에 라벨 추가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)