### PR TITLE
refactor: Lua import 필터링 변수명 개선 (fnName → luaRequireFn)

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -1395,9 +1395,9 @@ func (p *TreeSitterParser) extractImports(
 			break
 		}
 
-		// fnName holds the value of @_fn capture for function-call import patterns
+		// luaRequireFn holds the value of @_fn capture for Lua function-call import patterns
 		// (e.g., Lua require()). Used for Go-side predicate filtering.
-		fnName := ""
+		luaRequireFn := ""
 		var importNode *sitter.Node
 
 		for _, capture := range match.Captures {
@@ -1408,15 +1408,15 @@ func (p *TreeSitterParser) extractImports(
 			switch name {
 			case CaptureImportPath:
 				importNode = &node
-			case CaptureImportFn:
-				fnName = text
+			case CaptureLuaRequireFn:
+				luaRequireFn = text
 			}
 		}
 
 		// Go-side filtering: if @_fn was captured, it must be "require".
 		// The tree-sitter (#eq? @_fn "require") predicate is not evaluated
 		// by the go-tree-sitter binding at runtime, so we enforce it here.
-		if fnName != "" && fnName != "require" {
+		if luaRequireFn != "" && luaRequireFn != "require" {
 			continue
 		}
 

--- a/pkg/parser/treesitter/query.go
+++ b/pkg/parser/treesitter/query.go
@@ -35,10 +35,10 @@ const (
 // Capture names for import queries.
 const (
 	CaptureImportPath = "import_path"
-	// CaptureImportFn captures the function name in a function-call import pattern
+	// CaptureLuaRequireFn captures the function name in a Lua function-call import pattern
 	// (e.g., Lua's require()). Used for Go-side filtering when tree-sitter predicates
 	// (such as #eq?) are not evaluated by the binding at runtime.
-	CaptureImportFn = "_fn"
+	CaptureLuaRequireFn = "_fn"
 )
 
 // DefaultKindMapping provides default kind mappings (can be overridden per language).


### PR DESCRIPTION
## Summary
- `fnName` → `luaRequireFn`으로 변경하여 변수 목적 명확화
- `CaptureImportFn` → `CaptureLuaRequireFn` 상수명 변경
- Go-side predicate filtering 로직에 적용

## Test plan
- [x] `go test ./pkg/parser/treesitter/...` 통과

Closes #110