### PR TITLE
perf: 빈 문자열에 대한 불필요한 cleanComment 호출 방지

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -186,7 +186,9 @@ func (p *TreeSitterParser) extractSignatures(
 				sig.Line = int(node.StartPosition().Row) + 1
 				sig.EndLine = int(node.EndPosition().Row) + 1
 			case CaptureDoc:
-				sig.Doc = cleanComment(text)
+				if text != "" {
+					sig.Doc = cleanComment(text)
+				}
 			case CaptureKind:
 				kindNode = &node
 			}


### PR DESCRIPTION
## Summary
- 빈 문자열 체크를 추가하여 불필요한 `cleanComment` 호출 방지
- `strings.Split`, `strings.TrimPrefix` 등 내부 로직 스킵

## Test plan
- [x] `go test ./pkg/parser/treesitter/...` 통과

Closes #90