### PR TITLE
perf: stripTSFunctionBody에서 중복 문자열 스캔 제거

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -522,12 +522,9 @@ func stripTypeScriptBody(text, kind string) string {
 // It handles regular functions, methods, and arrow functions.
 func stripTSFunctionBody(text string) string {
 	// Handle arrow functions: const foo = (args): type => { body } or const foo = (args): type => expr
-	if strings.Contains(text, "=>") {
-		arrowIdx := strings.Index(text, "=>")
-		if arrowIdx > 0 {
-			// Remove everything from => onwards, keep only the signature
-			return strings.TrimSpace(text[:arrowIdx])
-		}
+	if arrowIdx := strings.Index(text, "=>"); arrowIdx > 0 {
+		// Remove everything from => onwards, keep only the signature
+		return strings.TrimSpace(text[:arrowIdx])
 	}
 
 	// Handle regular functions: function foo(args): type { body }


### PR DESCRIPTION
## Summary
- `strings.Contains` + `strings.Index`를 단일 `strings.Index`로 병합
- 동일 문자열을 2회 순회하던 것을 1회로 최적화

## Test plan
- [x] `go test ./pkg/parser/treesitter/...` 통과

Closes #86