### PR TITLE
refactor: 사용되지 않는 TypeScript regex 변수 제거

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -2,7 +2,6 @@ package treesitter
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -467,16 +466,6 @@ func stripGoBody(text, kind string) string {
 	}
 	return text
 }
-
-// Regex patterns for TypeScript body stripping
-var (
-	// Matches function body: starts with { and ends with matching }
-	tsFunctionBodyRe = regexp.MustCompile(`\s*\{[\s\S]*\}\s*$`)
-	// Matches arrow function body: => { ... } or => expression
-	tsArrowBodyRe = regexp.MustCompile(`\s*=>\s*[\s\S]+$`)
-	// Matches class body
-	tsClassBodyRe = regexp.MustCompile(`\s*\{[\s\S]*\}\s*$`)
-)
 
 // stripTypeScriptBody removes the body from TypeScript/JavaScript declarations.
 func stripTypeScriptBody(text, kind string) string {


### PR DESCRIPTION
## Summary
- 3개의 미사용 TypeScript regex 변수 삭제 (`tsFunctionBodyRe`, `tsArrowBodyRe`, `tsClassBodyRe`)
- `regexp` import 제거

`stripTypeScriptBody()` 함수는 이미 수동 문자 스캔 방식을 사용하고 있어 이 regex들은 dead code였습니다.

## Test plan
- [x] `go test ./pkg/parser/treesitter/...` 통과

Closes #85