### PR TITLE
fix: Tree-sitter 노드 바이트 범위에 명시적 바운드 체크 추가 (#137)

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -231,7 +231,11 @@ func (p *TreeSitterParser) extractSignatures(
 		for _, capture := range match.Captures {
 			name := captureNames[capture.Index]
 			node := capture.Node
-			text := string(content[node.StartByte():node.EndByte()])
+			start, end := node.StartByte(), node.EndByte()
+			if end > uint(len(content)) || start > end {
+				continue
+			}
+			text := string(content[start:end])
 
 			switch name {
 			case CaptureName:
@@ -1473,7 +1477,11 @@ func (p *TreeSitterParser) extractImports(
 		for _, capture := range match.Captures {
 			name := captureNames[capture.Index]
 			node := capture.Node
-			text := string(content[node.StartByte():node.EndByte()])
+			start, end := node.StartByte(), node.EndByte()
+			if end > uint(len(content)) || start > end {
+				continue
+			}
+			text := string(content[start:end])
 
 			switch name {
 			case CaptureImportPath:


### PR DESCRIPTION
## Summary
- `extractSignatures`와 `extractImports`의 캡처 루프에 바이트 범위 검증 추가
- `end > len(content)` 또는 `start > end`인 경우 해당 캡처를 안전하게 스킵
- 기존 panic recovery(#68)를 보완하는 명시적 방어 계층

Closes #137

## Test plan
- [x] `go test ./pkg/parser/treesitter/...` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)