### PR TITLE
fix: 바이너리 파일 감지 및 파싱 스킵 로직 추가 (#134)

### DIFF
--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -2,6 +2,7 @@
 package extractor
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"runtime"
@@ -176,6 +177,19 @@ func (e *FileExtractor) extractSequential(files []scanner.FileEntry, opts *Extra
 	return result
 }
 
+// binarySniffSize is the number of bytes inspected for NUL to detect binary content.
+const binarySniffSize = 512
+
+// isBinaryContent reports whether content appears to be binary by checking
+// for a NUL byte in the first 512 bytes.
+func isBinaryContent(content []byte) bool {
+	sniff := content
+	if len(sniff) > binarySniffSize {
+		sniff = sniff[:binarySniffSize]
+	}
+	return bytes.ContainsRune(sniff, 0)
+}
+
 // extractFile extracts signatures from a single file.
 func (e *FileExtractor) extractFile(entry scanner.FileEntry, opts *ExtractOptions) ExtractedFile {
 	extracted := ExtractedFile{
@@ -195,6 +209,12 @@ func (e *FileExtractor) extractFile(entry scanner.FileEntry, opts *ExtractOption
 	content, err := os.ReadFile(entry.Path)
 	if err != nil {
 		extracted.Error = fmt.Errorf("failed to read file: %w", err)
+		return extracted
+	}
+
+	// Skip binary files
+	if isBinaryContent(content) {
+		extracted.Error = fmt.Errorf("skipping binary file: %s", entry.Path)
 		return extracted
 	}
 


### PR DESCRIPTION
## Summary
- `isBinaryContent()` 헬퍼 함수 추가: 첫 512바이트에서 NUL 바이트 검사 (Git과 동일한 휴리스틱)
- `extractFile`에서 파일 읽기 후 바이너리 감지 시 파싱 스킵
- 기존 에러 처리 패턴과 일관된 방식으로 `ExtractedFile.Error` 설정

Closes #134

## Test plan
- [x] `go test ./...` 전체 통과
- [x] `gofmt` / `go vet` 이슈 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)