### PR TITLE
refactor: XML/JSON 포맷터의 kind 매핑 로직 통합 (#138)

### DIFF
--- a/pkg/formatter/helpers.go
+++ b/pkg/formatter/helpers.go
@@ -1,5 +1,21 @@
 package formatter
 
+// normalizeKind normalizes a signature kind string to one of the canonical
+// categories: "function", "type", or "variable". If the kind does not match
+// any known category, it is returned unchanged.
+func normalizeKind(kind string) string {
+	switch kind {
+	case "function", "method", "constructor", "destructor", "arrow", "local_function", "module_function":
+		return "function"
+	case "class", "interface", "type", "struct", "enum", "record", "annotation", "typedef", "namespace", "template":
+		return "type"
+	case "variable", "field", "macro", "export":
+		return "variable"
+	default:
+		return kind
+	}
+}
+
 // getEmptyComment returns the appropriate empty file comment for a language.
 func getEmptyComment(lang string) string {
 	switch lang {

--- a/pkg/formatter/json.go
+++ b/pkg/formatter/json.go
@@ -86,16 +86,3 @@ func (f *JSONFormatter) Format(data *PackageData) ([]byte, error) {
 	return json.Marshal(output)
 }
 
-// normalizeKind normalizes signature kinds for JSON output.
-func normalizeKind(kind string) string {
-	switch kind {
-	case "function", "method", "constructor", "destructor", "arrow", "local_function", "module_function":
-		return "function"
-	case "class", "interface", "type", "struct", "enum", "record", "annotation", "typedef", "namespace", "template":
-		return "type"
-	case "variable", "field", "macro", "export":
-		return "variable"
-	default:
-		return kind
-	}
-}

--- a/pkg/formatter/xml.go
+++ b/pkg/formatter/xml.go
@@ -159,14 +159,13 @@ func escapeXML(s string) string {
 }
 
 // kindToTag maps a signature Kind to the appropriate XML tag name.
+// It uses normalizeKind for the common mapping and falls back to "signature"
+// for unknown or empty kinds.
 func kindToTag(kind string) string {
-	switch kind {
-	case "function", "method", "constructor", "destructor", "arrow", "local_function", "module_function":
-		return "function"
-	case "class", "interface", "type", "struct", "enum", "record", "annotation", "typedef", "namespace", "template":
-		return "type"
-	case "variable", "field", "macro", "export":
-		return "variable"
+	result := normalizeKind(kind)
+	switch result {
+	case "function", "type", "variable":
+		return result
 	default:
 		return "signature" // fallback for empty or unknown kinds
 	}


### PR DESCRIPTION
## Summary
- `xml.go`의 `kindToTag()`와 `json.go`의 `normalizeKind()` 중복 제거
- 공통 매핑 로직을 `helpers.go`의 `normalizeKind()`로 추출
- XML은 unknown kind에 "signature" 반환, JSON은 원본 kind 반환하는 차이 유지

Closes #138

## Test plan
- [x] `go test ./...` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)