### PR TITLE
perf: 캡처 루프에서 CaptureKind의 불필요한 string 변환 제거 (#132)

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -231,6 +231,12 @@ func (p *TreeSitterParser) extractSignatures(
 		for _, capture := range match.Captures {
 			name := captureNames[capture.Index]
 			node := capture.Node
+
+			if name == CaptureKind {
+				kindNode = &node
+				continue
+			}
+
 			start, end := node.StartByte(), node.EndByte()
 			if end > uint(len(content)) || start > end {
 				continue
@@ -248,8 +254,6 @@ func (p *TreeSitterParser) extractSignatures(
 				if text != "" {
 					sig.Doc = cleanComment(text)
 				}
-			case CaptureKind:
-				kindNode = &node
 			}
 		}
 


### PR DESCRIPTION
## Summary
- `CaptureKind` 분기에서 `text` 변수를 사용하지 않으므로 early-continue 적용
- 바이트→문자열 변환 및 바운드 체크를 스킵하여 캡처당 불필요한 할당 제거

Closes #132

## Test plan
- [x] `go test ./pkg/parser/treesitter/...` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)