### PR TITLE
perf: removeBlankLines를 단일 패스 구현으로 개선

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -1527,13 +1527,17 @@ func (p *TreeSitterParser) extractImports(
 // This is used to clean up Go import blocks that may have blank lines
 // between import groups.
 func removeBlankLines(text string) string {
-	lines := strings.Split(text, "\n")
-	var result []string
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" {
-			result = append(result, line)
+	var buf strings.Builder
+	buf.Grow(len(text))
+	first := true
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) != "" {
+			if !first {
+				buf.WriteByte('\n')
+			}
+			buf.WriteString(line)
+			first = false
 		}
 	}
-	return strings.Join(result, "\n")
+	return buf.String()
 }


### PR DESCRIPTION
## Summary
- `removeBlankLines` 함수를 `[]string` 슬라이스 할당 + `strings.Join` 방식에서 `strings.Builder` 단일 패스로 변경
- 중간 슬라이스 할당 제거로 메모리 효율성 향상

Closes #136

## Test plan
- [x] `go test ./...` 전체 통과