### PR TITLE
perf: sync.Pool을 활용한 Tree-sitter Parser 풀링

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -159,11 +159,10 @@ func (p *TreeSitterParser) Parse(content []byte, opts *parser.Options) (result *
 
 	// Parse content (no conversion needed - already []byte)
 	tree := sitterParser.Parse(content, nil)
-	defer tree.Close()
-
 	if tree == nil {
 		return nil, fmt.Errorf("failed to parse content")
 	}
+	defer tree.Close()
 
 	// Extract signatures
 	signatures, err := p.extractSignatures(tree.RootNode(), content, query, opts)


### PR DESCRIPTION
## Summary
- `Parse()` 호출 시마다 `sitter.NewParser()` + `Close()`하던 것을 `sync.Pool`로 재사용
- CGO 경계 횡단(할당/해제) 오버헤드를 병렬 처리 환경에서 대폭 감소

Closes #131

## Test plan
- [x] `go test ./...` 전체 통과