### PR TITLE
perf: sync.Pool을 활용한 QueryCursor 풀링

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -51,6 +51,7 @@ type TreeSitterParser struct {
 	compiledQueries  sync.Map // map[queryCacheKey]*sitter.Query
 	queryCacheMutex  sync.RWMutex
 	parserPool       sync.Pool
+	cursorPool       sync.Pool
 }
 
 // NewTreeSitterParser creates a new Tree-sitter based parser.
@@ -78,6 +79,11 @@ func NewTreeSitterParser() *TreeSitterParser {
 	p.parserPool = sync.Pool{
 		New: func() any {
 			return sitter.NewParser()
+		},
+	}
+	p.cursorPool = sync.Pool{
+		New: func() any {
+			return sitter.NewQueryCursor()
 		},
 	}
 	return p
@@ -212,8 +218,8 @@ func (p *TreeSitterParser) extractSignatures(
 	// Note: query.Close() is NOT called here because the query is cached for reuse
 
 	// Execute query
-	qc := sitter.NewQueryCursor()
-	defer qc.Close()
+	qc := p.cursorPool.Get().(*sitter.QueryCursor)
+	defer p.cursorPool.Put(qc)
 
 	matches := qc.Matches(query, root, content)
 
@@ -1464,8 +1470,8 @@ func (p *TreeSitterParser) extractImports(
 	// Note: query.Close() is NOT called here because the query is cached for reuse
 
 	// Execute query
-	qc := sitter.NewQueryCursor()
-	defer qc.Close()
+	qc := p.cursorPool.Get().(*sitter.QueryCursor)
+	defer p.cursorPool.Put(qc)
 
 	matches := qc.Matches(query, root, content)
 	captureNames := query.CaptureNames()


### PR DESCRIPTION
## Summary
- `extractSignatures`와 `extractImports`에서 매번 `NewQueryCursor()` + `Close()`하던 것을 `sync.Pool`로 재사용
- #131 Parser 풀링과 함께 CGO 경계 횡단 오버헤드 대폭 감소

Closes #135

## Test plan
- [x] `go test ./...` 전체 통과