### PR TITLE
feat: Fuzzing 테스트 추가

### DIFF
--- a/pkg/formatter/formatter_fuzz_test.go
+++ b/pkg/formatter/formatter_fuzz_test.go
@@ -1,0 +1,253 @@
+package formatter
+
+import (
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// FuzzXMLFormatter tests that the XML formatter does not panic on arbitrary data.
+func FuzzXMLFormatter(f *testing.F) {
+	// Seed corpus with various PackageData scenarios
+	f.Add([]byte("test"), []byte("func main()"), []byte("doc"))
+	f.Add([]byte(""), []byte(""), []byte(""))
+	f.Add([]byte("path/with/unicode/한글/路径"), []byte(""), []byte(""))
+	f.Add([]byte("path"), []byte("func <script>alert('xss')</script>()"), []byte(""))
+	f.Add([]byte("path"), []byte("func test()"), []byte("doc with \"quotes\" and 'apostrophes'"))
+	f.Add(make([]byte, 10000), make([]byte, 10000), make([]byte, 10000))
+
+	formatter := NewXMLFormatter()
+
+	f.Fuzz(func(t *testing.T, path, sigText, doc []byte) {
+		data := &PackageData{
+			Version:  "v0.1.0",
+			RootPath: "/test",
+			Tree:     "test/\n└── test.go",
+			Files: []FileData{
+				{
+					Path:     string(path),
+					Language: "go",
+					Signatures: []parser.Signature{
+						{
+							Name:     "Test",
+							Kind:     "function",
+							Text:     string(sigText),
+							Doc:      string(doc),
+							Line:     1,
+							Language: "go",
+							Exported: true,
+						},
+					},
+				},
+			},
+			TotalSignatures: 1,
+		}
+
+		// The formatter should not panic on any input
+		output, err := formatter.Format(data)
+		if err != nil {
+			// Error is acceptable, panic is not
+			return
+		}
+		// Output should be valid XML bytes
+		if output == nil {
+			t.Error("expected non-nil output on successful format")
+		}
+	})
+}
+
+// FuzzMarkdownFormatter tests that the Markdown formatter does not panic on arbitrary data.
+func FuzzMarkdownFormatter(f *testing.F) {
+	f.Add([]byte("test"), []byte("func main()"), []byte("doc"))
+	f.Add([]byte(""), []byte(""), []byte(""))
+	f.Add([]byte("path/with/special#chars"), []byte(""), []byte(""))
+	f.Add([]byte("path"), []byte("func **bold**()"), []byte(""))
+	f.Add([]byte("path"), []byte("func test()"), []byte("doc with [link](url)"))
+	f.Add(make([]byte, 10000), make([]byte, 10000), make([]byte, 10000))
+
+	formatter := NewMarkdownFormatter()
+
+	f.Fuzz(func(t *testing.T, path, sigText, doc []byte) {
+		data := &PackageData{
+			Version:  "v0.1.0",
+			RootPath: "/test",
+			Tree:     "test/\n└── test.go",
+			Files: []FileData{
+				{
+					Path:     string(path),
+					Language: "go",
+					Signatures: []parser.Signature{
+						{
+							Name:     "Test",
+							Kind:     "function",
+							Text:     string(sigText),
+							Doc:      string(doc),
+							Line:     1,
+							Language: "go",
+							Exported: true,
+						},
+					},
+				},
+			},
+			TotalSignatures: 1,
+		}
+
+		output, err := formatter.Format(data)
+		if err != nil {
+			return
+		}
+		if output == nil {
+			t.Error("expected non-nil output on successful format")
+		}
+	})
+}
+
+// FuzzJSONFormatter tests that the JSON formatter does not panic on arbitrary data.
+func FuzzJSONFormatter(f *testing.F) {
+	f.Add([]byte("test"), []byte("func main()"), []byte("doc"))
+	f.Add([]byte(""), []byte(""), []byte(""))
+	f.Add([]byte("path/with/unicode/日本語"), []byte(""), []byte(""))
+	f.Add([]byte("path"), []byte("func \"quoted\"()"), []byte(""))
+	f.Add([]byte("path"), []byte("func test()"), []byte("doc with\nnewlines\tand\ttabs"))
+	f.Add(make([]byte, 10000), make([]byte, 10000), make([]byte, 10000))
+
+	formatter := NewJSONFormatter()
+
+	f.Fuzz(func(t *testing.T, path, sigText, doc []byte) {
+		data := &PackageData{
+			Version:  "v0.1.0",
+			RootPath: "/test",
+			Tree:     "test/\n└── test.go",
+			Files: []FileData{
+				{
+					Path:     string(path),
+					Language: "go",
+					Signatures: []parser.Signature{
+						{
+							Name:     "Test",
+							Kind:     "function",
+							Text:     string(sigText),
+							Doc:      string(doc),
+							Line:     1,
+							Language: "go",
+							Exported: true,
+						},
+					},
+				},
+			},
+			TotalSignatures: 1,
+		}
+
+		output, err := formatter.Format(data)
+		if err != nil {
+			return
+		}
+		if output == nil {
+			t.Error("expected non-nil output on successful format")
+		}
+	})
+}
+
+// FuzzFormatterWithLargeData tests formatters with large amounts of data.
+func FuzzFormatterWithLargeData(f *testing.F) {
+	f.Add(100, 100) // numFiles, numSigsPerFile
+
+	formatters := []Formatter{
+		NewXMLFormatter(),
+		NewMarkdownFormatter(),
+		NewJSONFormatter(),
+	}
+
+	f.Fuzz(func(t *testing.T, numFiles, numSigsPerFile int) {
+		// Limit to reasonable sizes to avoid timeout
+		if numFiles > 1000 {
+			numFiles = 1000
+		}
+		if numSigsPerFile > 100 {
+			numSigsPerFile = 100
+		}
+		if numFiles < 0 {
+			numFiles = 0
+		}
+		if numSigsPerFile < 0 {
+			numSigsPerFile = 0
+		}
+
+		files := make([]FileData, numFiles)
+		for i := 0; i < numFiles; i++ {
+			sigs := make([]parser.Signature, numSigsPerFile)
+			for j := 0; j < numSigsPerFile; j++ {
+				sigs[j] = parser.Signature{
+					Name:     "Func",
+					Kind:     "function",
+					Text:     "func Func()",
+					Line:     j + 1,
+					Language: "go",
+					Exported: true,
+				}
+			}
+			files[i] = FileData{
+				Path:       "file.go",
+				Language:   "go",
+				Signatures: sigs,
+			}
+		}
+
+		data := &PackageData{
+			Version:         "v0.1.0",
+			RootPath:        "/test",
+			Files:           files,
+			TotalSignatures: numFiles * numSigsPerFile,
+		}
+
+		for _, formatter := range formatters {
+			output, err := formatter.Format(data)
+			if err != nil {
+				continue
+			}
+			if output == nil && numFiles > 0 {
+				t.Errorf("formatter %s: expected non-nil output", formatter.Name())
+			}
+		}
+	})
+}
+
+// FuzzFormatterWithImports tests formatters with import data.
+func FuzzFormatterWithImports(f *testing.F) {
+	f.Add([]byte("import \"fmt\""), []byte("import \"os\""), true)
+
+	formatters := []Formatter{
+		NewXMLFormatter(),
+		NewMarkdownFormatter(),
+		NewJSONFormatter(),
+	}
+
+	f.Fuzz(func(t *testing.T, imp1, imp2 []byte, includeImports bool) {
+		data := &PackageData{
+			Version: "v0.1.0",
+			Files: []FileData{
+				{
+					Path:       "a.go",
+					Language:   "go",
+					RawImports: []string{string(imp1)},
+				},
+				{
+					Path:       "b.go",
+					Language:   "go",
+					RawImports: []string{string(imp2)},
+				},
+			},
+			IncludeImports: includeImports,
+		}
+
+		for _, formatter := range formatters {
+			output, err := formatter.Format(data)
+			if err != nil {
+				continue
+			}
+			if output == nil {
+				t.Errorf("formatter %s: expected non-nil output", formatter.Name())
+			}
+		}
+	})
+}

--- a/pkg/formatter/xml.go
+++ b/pkg/formatter/xml.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"unicode/utf8"
 )
 
 // XMLFormatter implements Formatter for XML output.
@@ -159,17 +158,6 @@ func escapeXML(s string) string {
 	}
 
 	return buf.String()
-}
-
-// truncateDoc truncates a documentation string to maxLen characters (Unicode code points).
-// If maxLen is 0 or negative, the original string is returned unchanged.
-// Truncated strings end with "..." to indicate truncation.
-func truncateDoc(doc string, maxLen int) string {
-	if maxLen <= 0 || utf8.RuneCountInString(doc) <= maxLen {
-		return doc
-	}
-	runes := []rune(doc)
-	return string(runes[:maxLen]) + "..."
 }
 
 // kindToTag maps a signature Kind to the appropriate XML tag name.

--- a/pkg/parser/treesitter/parser_fuzz_test.go
+++ b/pkg/parser/treesitter/parser_fuzz_test.go
@@ -1,0 +1,162 @@
+package treesitter
+
+import (
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// FuzzParseGo tests that the Go parser does not panic on arbitrary input.
+func FuzzParseGo(f *testing.F) {
+	// Add seed corpus with valid and invalid Go code
+	f.Add([]byte("package main\n\nfunc main() {}"))
+	f.Add([]byte("func Add(a, b int) int { return a + b }"))
+	f.Add([]byte("type Foo struct { Name string }"))
+	f.Add([]byte(""))  // empty input
+	f.Add([]byte("\x00")) // null byte
+	f.Add([]byte("package main\n\n/* " + string(make([]byte, 10000)))) // large unclosed comment
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// The parser should not panic on any input
+		result, err := tsParser.Parse(data, nil)
+		if err != nil {
+			// Error is acceptable, panic is not
+			return
+		}
+		// Result should be valid
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}
+
+// FuzzParseTypeScript tests that the TypeScript parser does not panic on arbitrary input.
+func FuzzParseTypeScript(f *testing.F) {
+	f.Add([]byte("function main() {}"))
+	f.Add([]byte("const x: number = 1;"))
+	f.Add([]byte("interface Foo { name: string }"))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00"))
+	f.Add([]byte("function test() { return `" + string(make([]byte, 5000)) + "` }"))
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := tsParser.Parse(data, &parser.Options{Language: "typescript"})
+		if err != nil {
+			return
+		}
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}
+
+// FuzzParsePython tests that the Python parser does not panic on arbitrary input.
+func FuzzParsePython(f *testing.F) {
+	f.Add([]byte("def main():\n    pass"))
+	f.Add([]byte("class Foo:\n    def __init__(self):\n        pass"))
+	f.Add([]byte("import os\nfrom typing import List"))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00"))
+	f.Add([]byte("def f():\n    " + string(make([]byte, 5000))))
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := tsParser.Parse(data, &parser.Options{Language: "python"})
+		if err != nil {
+			return
+		}
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}
+
+// FuzzParseJava tests that the Java parser does not panic on arbitrary input.
+func FuzzParseJava(f *testing.F) {
+	f.Add([]byte("public class Main { public static void main(String[] args) {} }"))
+	f.Add([]byte("interface Foo { void bar(); }"))
+	f.Add([]byte("package com.example;"))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00"))
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := tsParser.Parse(data, &parser.Options{Language: "java"})
+		if err != nil {
+			return
+		}
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}
+
+// FuzzParseRust tests that the Rust parser does not panic on arbitrary input.
+func FuzzParseRust(f *testing.F) {
+	f.Add([]byte("fn main() {}"))
+	f.Add([]byte("struct Foo { name: String }"))
+	f.Add([]byte("use std::collections::HashMap;"))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00"))
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := tsParser.Parse(data, &parser.Options{Language: "rust"})
+		if err != nil {
+			return
+		}
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}
+
+// FuzzParseC tests that the C parser does not panic on arbitrary input.
+func FuzzParseC(f *testing.F) {
+	f.Add([]byte("int main() { return 0; }"))
+	f.Add([]byte("struct Foo { int x; };"))
+	f.Add([]byte("#include <stdio.h>"))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00"))
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := tsParser.Parse(data, &parser.Options{Language: "c"})
+		if err != nil {
+			return
+		}
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}
+
+// FuzzParseJSON tests JSON parsing (via JavaScript/TypeScript parser).
+func FuzzParseJSON(f *testing.F) {
+	f.Add([]byte(`{"key": "value"}`))
+	f.Add([]byte(`[1, 2, 3]`))
+	f.Add([]byte(`{"nested": {"a": 1}}`))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00"))
+	f.Add([]byte(`{"a": ` + string(make([]byte, 10000)) + `}`))
+
+	tsParser := NewTreeSitterParser()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := tsParser.Parse(data, &parser.Options{Language: "javascript"})
+		if err != nil {
+			return
+		}
+		if result == nil {
+			t.Error("expected non-nil result on successful parse")
+		}
+	})
+}


### PR DESCRIPTION
## 개요

입력 검증 강화를 위한 fuzzing 테스트를 추가합니다.

## 작업 내용

- [x] Parser fuzzing 테스트 (Go, TypeScript, Python, Java, Rust, C, JSON)
- [x] Formatter fuzzing 테스트 (XML, Markdown, JSON)
- [ ] Scanner 입력 fuzzing
- [ ] CI에 fuzzing 통합 (oss-fuzz)

## Fuzzing 테스트 내용

### Parser Fuzzing (`pkg/parser/treesitter/parser_fuzz_test.go`)
- 다양한 언어에 대한 파서가 임의의 입력에 대해 panic 하지 않음을 검증
- 빈 입력, null byte, 큰 데이터 등 엣지 케이스 포함

### Formatter Fuzzing (`pkg/formatter/formatter_fuzz_test.go`)
- XML, Markdown, JSON 포매터가 임의의 데이터에 대해 panic 하지 않음을 검증
- 유니코드 경로, 특수 문자, 큰 데이터 등 테스트

Closes #47