### PR TITLE
feat: Codecov 통합 및 테스트 커버리지 CI 추가

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,34 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests with coverage
+        run: go test ./... -v -coverprofile=coverage.out -covermode=atomic
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Build
+        run: go build ./cmd/brfit

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Release](https://img.shields.io/github/v/release/indigo-net/Brf.it)](https://github.com/indigo-net/Brf.it/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/indigo-net/Brf.it)](https://goreportcard.com/report/github.com/indigo-net/Brf.it)
+[![Coverage](https://codecov.io/gh/indigo-net/Brf.it/branch/main/graph/badge.svg)](https://codecov.io/gh/indigo-net/Brf.it)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **Package your codebase for AI comprehension.**


### PR DESCRIPTION
## 개요

Codecov를 통합하여 PR마다 테스트 커버리지 리포트를 생성합니다.

## 작업 내용

- [x] `go test -coverprofile=coverage.out` 스크립트
- [x] GitHub Actions에 codecov step 추가
- [x] README에 커버리지 뱃지 추가

## 워크플로우 내용

```yaml
- name: Run tests with coverage
  run: go test ./... -v -coverprofile=coverage.out -covermode=atomic

- name: Upload coverage to Codecov
  uses: codecov/codecov-action@v4
```

## 참고

- Codecov 계정 설정 및 `CODECOV_TOKEN` secret은 별도 설정 필요

Closes #44