### PR TITLE
feat: 성능 벤치마크 테스트 추가

### DIFF
--- a/pkg/formatter/formatter_bench_test.go
+++ b/pkg/formatter/formatter_bench_test.go
@@ -1,0 +1,182 @@
+package formatter
+
+import (
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// createBenchmarkData creates PackageData for benchmarking.
+func createBenchmarkData(numFiles, numSigsPerFile int) *PackageData {
+	files := make([]FileData, numFiles)
+	for i := 0; i < numFiles; i++ {
+		sigs := make([]parser.Signature, numSigsPerFile)
+		for j := 0; j < numSigsPerFile; j++ {
+			sigs[j] = parser.Signature{
+				Name:     "FunctionName",
+				Kind:     "function",
+				Text:     "func FunctionName(a int, b string) (result error)",
+				Doc:      "FunctionName does something useful with the given parameters.",
+				Line:     j + 1,
+				Language: "go",
+				Exported: true,
+			}
+		}
+		files[i] = FileData{
+			Path:       "pkg/module/file.go",
+			Language:   "go",
+			Signatures: sigs,
+		}
+	}
+
+	return &PackageData{
+		Version:         "v0.1.0",
+		RootPath:        "/project",
+		Tree:            "pkg/\n└── module/\n    └── file.go",
+		Files:           files,
+		TotalSignatures: numFiles * numSigsPerFile,
+	}
+}
+
+// BenchmarkXMLFormatter benchmarks XML formatting with varying data sizes.
+func BenchmarkXMLFormatter(b *testing.B) {
+	tests := []struct {
+		name          string
+		numFiles      int
+		numSigsPerFile int
+	}{
+		{"small_5files_10sigs", 5, 10},
+		{"medium_20files_50sigs", 20, 50},
+		{"large_50files_100sigs", 50, 100},
+		{"xlarge_100files_200sigs", 100, 200},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			data := createBenchmarkData(tt.numFiles, tt.numSigsPerFile)
+			f := NewXMLFormatter()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := f.Format(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMarkdownFormatter benchmarks Markdown formatting.
+func BenchmarkMarkdownFormatter(b *testing.B) {
+	tests := []struct {
+		name          string
+		numFiles      int
+		numSigsPerFile int
+	}{
+		{"small_5files_10sigs", 5, 10},
+		{"medium_20files_50sigs", 20, 50},
+		{"large_50files_100sigs", 50, 100},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			data := createBenchmarkData(tt.numFiles, tt.numSigsPerFile)
+			f := NewMarkdownFormatter()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := f.Format(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkJSONFormatter benchmarks JSON formatting.
+func BenchmarkJSONFormatter(b *testing.B) {
+	tests := []struct {
+		name          string
+		numFiles      int
+		numSigsPerFile int
+	}{
+		{"small_5files_10sigs", 5, 10},
+		{"medium_20files_50sigs", 20, 50},
+		{"large_50files_100sigs", 50, 100},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			data := createBenchmarkData(tt.numFiles, tt.numSigsPerFile)
+			f := NewJSONFormatter()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := f.Format(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkXMLFormatterWithImports benchmarks XML formatting with imports.
+func BenchmarkXMLFormatterWithImports(b *testing.B) {
+	data := createBenchmarkData(10, 20)
+
+	// Add imports to files
+	for i := range data.Files {
+		data.Files[i].RawImports = []string{
+			`import "fmt"`,
+			`import "strings"`,
+			`import "os"`,
+		}
+	}
+	data.IncludeImports = true
+
+	f := NewXMLFormatter()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := f.Format(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFormatterComparison compares all formatters.
+func BenchmarkFormatterComparison(b *testing.B) {
+	data := createBenchmarkData(20, 50)
+
+	formatters := map[string]Formatter{
+		"xml":      NewXMLFormatter(),
+		"markdown": NewMarkdownFormatter(),
+		"json":     NewJSONFormatter(),
+	}
+
+	for name, f := range formatters {
+		b.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := f.Format(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/parser/treesitter/parser_bench_test.go
+++ b/pkg/parser/treesitter/parser_bench_test.go
@@ -1,0 +1,162 @@
+package treesitter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// BenchmarkParseGo benchmarks parsing Go code of varying sizes.
+func BenchmarkParseGo(b *testing.B) {
+	tests := []struct {
+		name     string
+		funcs    int
+		docLines int
+	}{
+		{"small_10funcs_0doc", 10, 0},
+		{"medium_50funcs_5doc", 50, 5},
+		{"large_100funcs_10doc", 100, 10},
+		{"xlarge_500funcs_20doc", 500, 20},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			// Generate Go code
+			var code strings.Builder
+			code.WriteString("package main\n\n")
+
+			for i := 0; i < tt.funcs; i++ {
+				// Add doc comments
+				for j := 0; j < tt.docLines; j++ {
+					code.WriteString("// This is documentation line for function.\n")
+				}
+				code.WriteString("func Func")
+				code.WriteString(string(rune('A' + i%26)))
+				code.WriteString("(a, b int) string {\n")
+				code.WriteString("\treturn \"result\"\n")
+				code.WriteString("}\n\n")
+			}
+
+			data := []byte(code.String())
+			p := NewTreeSitterParser()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := p.Parse(data, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkParseTypeScript benchmarks parsing TypeScript code.
+func BenchmarkParseTypeScript(b *testing.B) {
+	tests := []struct {
+		name   string
+		funcs  int
+	}{
+		{"small_10funcs", 10},
+		{"medium_50funcs", 50},
+		{"large_100funcs", 100},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			var code strings.Builder
+
+			for i := 0; i < tt.funcs; i++ {
+				code.WriteString("function func")
+				code.WriteString(string(rune('A' + i%26)))
+				code.WriteString("(a: number, b: string): void {\n")
+				code.WriteString("\tconsole.log(a, b);\n")
+				code.WriteString("}\n\n")
+			}
+
+			data := []byte(code.String())
+			p := NewTreeSitterParser()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := p.Parse(data, &parser.Options{Language: "typescript"})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkParsePython benchmarks parsing Python code.
+func BenchmarkParsePython(b *testing.B) {
+	tests := []struct {
+		name   string
+		funcs  int
+	}{
+		{"small_10funcs", 10},
+		{"medium_50funcs", 50},
+		{"large_100funcs", 100},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			var code strings.Builder
+
+			for i := 0; i < tt.funcs; i++ {
+				code.WriteString("def func")
+				code.WriteString(string(rune('a' + i%26)))
+				code.WriteString("(self, a, b):\n")
+				code.WriteString("    \"\"\"Documentation.\"\"\"\n")
+				code.WriteString("    return a + b\n\n")
+			}
+
+			data := []byte(code.String())
+			p := NewTreeSitterParser()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := p.Parse(data, &parser.Options{Language: "python"})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkParseWithImports benchmarks parsing with import extraction.
+func BenchmarkParseWithImports(b *testing.B) {
+	var code strings.Builder
+	code.WriteString("package main\n\n")
+
+	// Add imports
+	for i := 0; i < 20; i++ {
+		code.WriteString("import \"fmt\"\n")
+	}
+
+	// Add functions
+	for i := 0; i < 50; i++ {
+		code.WriteString("func F() { fmt.Println() }\n")
+	}
+
+	data := []byte(code.String())
+	p := NewTreeSitterParser()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := p.Parse(data, &parser.Options{IncludeImports: true})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/scanner/scanner_bench_test.go
+++ b/pkg/scanner/scanner_bench_test.go
@@ -1,0 +1,154 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// BenchmarkScanDirectory benchmarks scanning directories with varying file counts.
+func BenchmarkScanDirectory(b *testing.B) {
+	tests := []struct {
+		name      string
+		fileCount int
+	}{
+		{"10_files", 10},
+		{"50_files", 50},
+		{"100_files", 100},
+		{"500_files", 500},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			// Create temp directory with test files
+			tmpDir, err := os.MkdirTemp("", "benchmark-*")
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			// Create test files
+			for i := 0; i < tt.fileCount; i++ {
+				filename := filepath.Join(tmpDir, "file_"+string(rune('a'+i%26))+string(rune('0'+i%10))+".go")
+				content := []byte(`package test
+
+func Func` + string(rune('A'+i%26)) + `() int {
+	return ` + string(rune('0'+i%10)) + `
+}
+`)
+				if err := os.WriteFile(filename, content, 0644); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			opts := DefaultScanOptions()
+			opts.RootPath = tmpDir
+			s := NewScannerWithOptions(opts)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := s.Scan()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkScanLargeFile benchmarks scanning a single large file.
+func BenchmarkScanLargeFile(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "benchmark-large-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a large Go file
+	largeContent := []byte(`package test
+
+// LargeFile is a test file with many functions.
+`)
+
+	// Add many functions
+	for i := 0; i < 1000; i++ {
+		largeContent = append(largeContent, []byte(`
+func Func`+string(rune('A'+i%26))+string(rune('a'+(i/26)%26))+`() int {
+	// This is function number `+string(rune('0'+i%10))+`
+	return `+string(rune('0'+i%10))+`
+}
+`)...)
+	}
+
+	filename := filepath.Join(tmpDir, "large.go")
+	if err := os.WriteFile(filename, largeContent, 0644); err != nil {
+		b.Fatal(err)
+	}
+
+	opts := DefaultScanOptions()
+	opts.RootPath = tmpDir
+	s := NewScannerWithOptions(opts)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := s.Scan()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanWithIgnore benchmarks scanning with gitignore patterns.
+func BenchmarkScanWithIgnore(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "benchmark-ignore-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create directory structure
+	dirs := []string{"src", "vendor", "node_modules", ".git"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// Create files
+	for i := 0; i < 50; i++ {
+		for _, dir := range dirs {
+			filename := filepath.Join(tmpDir, dir, "file.go")
+			content := []byte(`package test; func F() {}`)
+			if err := os.WriteFile(filename, content, 0644); err != nil {
+				// Ignore if file exists
+			}
+		}
+	}
+
+	// Create .gitignore
+	gitignore := []byte(`vendor/
+node_modules/
+.git/
+`)
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), gitignore, 0644); err != nil {
+		b.Fatal(err)
+	}
+
+	opts := DefaultScanOptions()
+	opts.RootPath = tmpDir
+	s := NewScannerWithOptions(opts)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := s.Scan()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## 개요

대용량 파일/디렉토리 처리 성능을 측정하는 벤치마크 테스트를 추가합니다.

## 작업 내용

- [x] Scanner 벤치마크 (파일 수별: 10, 50, 100, 500)
- [x] Parser 벤치마크 (파일 크기별: small, medium, large, xlarge)
- [x] Formatter 벤치마크 (XML, Markdown, JSON)
- [x] 메모리 할당 측정 (`b.ReportAllocs()`)

## 벤치마크 구성

### Scanner (`pkg/scanner/scanner_bench_test.go`)
- `BenchmarkScanDirectory`: 파일 수별 스캔 성능
- `BenchmarkScanLargeFile`: 대용량 단일 파일
- `BenchmarkScanWithIgnore`: gitignore 패턴 처리

### Parser (`pkg/parser/treesitter/parser_bench_test.go`)
- `BenchmarkParseGo`: Go 코드 파싱 (10~500개 함수)
- `BenchmarkParseTypeScript`: TypeScript 파싱
- `BenchmarkParsePython`: Python 파싱
- `BenchmarkParseWithImports`: import 추출 포함

### Formatter (`pkg/formatter/formatter_bench_test.go`)
- `BenchmarkXMLFormatter`: XML 출력 성능
- `BenchmarkMarkdownFormatter`: Markdown 출력 성능
- `BenchmarkJSONFormatter`: JSON 출력 성능
- `BenchmarkFormatterComparison`: 포맷터 간 비교

## 실행 방법

```bash
# 전체 벤치마크 실행
go test -bench=. ./...

# 특정 패키지만
go test -bench=. ./pkg/scanner/...

# 상세 결과
go test -bench=. -benchmem ./...
```

Closes #45