### PR TITLE
feat: 에러 메시지 개선

### DIFF
--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -201,26 +201,26 @@ func (e *FileExtractor) extractFile(entry scanner.FileEntry, opts *ExtractOption
 	// Get parser for language
 	p, ok := e.registry.Get(entry.Language)
 	if !ok {
-		extracted.Error = fmt.Errorf("no parser for language: %s", entry.Language)
+		extracted.Error = fmt.Errorf("no parser for language %q in %q. Available parsers: go, typescript, tsx, javascript, jsx, python, c, java, cpp, rust, swift, kotlin, csharp, lua, shell, php, ruby, scala", entry.Language, entry.Path)
 		return extracted
 	}
 
 	// Read file content
 	content, err := os.ReadFile(entry.Path)
 	if err != nil {
-		extracted.Error = fmt.Errorf("failed to read file: %w", err)
+		extracted.Error = fmt.Errorf("failed to read file %q: %w", entry.Path, err)
 		return extracted
 	}
 
 	// Skip binary files
 	if isBinaryContent(content) {
-		extracted.Error = fmt.Errorf("skipping binary file: %s", entry.Path)
+		extracted.Error = fmt.Errorf("skipping binary file %q (detected NUL byte in content)", entry.Path)
 		return extracted
 	}
 
 	// TOCTOU guard: re-check file size after reading
 	if opts.MaxFileSize > 0 && int64(len(content)) > opts.MaxFileSize {
-		extracted.Error = fmt.Errorf("file size changed since scan: %s (%d > %d)",
+		extracted.Error = fmt.Errorf("file size changed since scan: %q (%d > %d bytes limit)",
 			entry.Path, len(content), opts.MaxFileSize)
 		return extracted
 	}
@@ -233,7 +233,7 @@ func (e *FileExtractor) extractFile(entry scanner.FileEntry, opts *ExtractOption
 		IncludeImports: opts.IncludeImports,
 	})
 	if err != nil {
-		extracted.Error = fmt.Errorf("failed to parse: %w", err)
+		extracted.Error = fmt.Errorf("failed to parse %q: %w", entry.Path, err)
 		return extracted
 	}
 

--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -41,6 +41,9 @@ const (
 	queryTypeImport
 )
 
+// supportedLangs is the list of languages with Tree-sitter parsers available.
+const supportedLangs = "go, typescript, tsx, javascript, jsx, python, c, java, cpp, rust, swift, kotlin, csharp, lua, shell, php, ruby, scala"
+
 // queryCacheKey combines language and query type for cache lookup.
 type queryCacheKey struct {
 	lang string
@@ -148,13 +151,13 @@ func (p *TreeSitterParser) Parse(content []byte, opts *parser.Options) (result *
 	// Determine language
 	lang := opts.Language
 	if lang == "" {
-		return nil, fmt.Errorf("language must be specified")
+		return nil, fmt.Errorf("language must be specified in Options.Language (received empty string). Supported: %s", supportedLangs)
 	}
 
 	// Get language query
 	query, ok := p.queries[lang]
 	if !ok {
-		return nil, fmt.Errorf("unsupported language: %s", lang)
+		return nil, fmt.Errorf("unsupported language %q. Available parsers: %s", lang, supportedLangs)
 	}
 
 	// Get parser from pool
@@ -164,13 +167,13 @@ func (p *TreeSitterParser) Parse(content []byte, opts *parser.Options) (result *
 	// Set language
 	tsLang := query.Language()
 	if err := sitterParser.SetLanguage(tsLang); err != nil {
-		return nil, fmt.Errorf("failed to set language: %w", err)
+		return nil, fmt.Errorf("failed to initialize %q parser: %w (grammar may be corrupted or incompatible)", lang, err)
 	}
 
 	// Parse content (no conversion needed - already []byte)
 	tree := sitterParser.Parse(content, nil)
 	if tree == nil {
-		return nil, fmt.Errorf("failed to parse content")
+		return nil, fmt.Errorf("failed to parse content for language %q (content may be malformed or parser error occurred)", lang)
 	}
 	defer tree.Close()
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -174,7 +174,7 @@ func (s *FileScanner) Scan() (*ScanResult, error) {
 	// Check if root path is a file
 	info, err := os.Stat(s.opts.RootPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot access path %q: %w", s.opts.RootPath, err)
 	}
 
 	if !info.IsDir() {
@@ -194,9 +194,9 @@ func (s *FileScanner) Scan() (*ScanResult, error) {
 			var warning string
 			switch {
 			case os.IsPermission(err):
-				warning = fmt.Sprintf("permission denied: %s", path)
+				warning = fmt.Sprintf("permission denied: %s (check file permissions or run with appropriate privileges)", path)
 			case os.IsNotExist(err):
-				warning = fmt.Sprintf("file not found: %s", path)
+				warning = fmt.Sprintf("file not found: %s (may have been deleted during scan)", path)
 			default:
 				warning = fmt.Sprintf("skipping: %s: %v", path, err)
 			}
@@ -207,7 +207,7 @@ func (s *FileScanner) Scan() (*ScanResult, error) {
 
 		// Skip symlinks
 		if d.Type()&os.ModeSymlink != 0 {
-			warning := fmt.Sprintf("skipping symlink: %s", path)
+			warning := fmt.Sprintf("skipping symlink: %s (symlinks are not followed for security)", path)
 			s.logger.Printf("WARN: %s", warning)
 			result.Warnings = append(result.Warnings, warning)
 			if d.IsDir() {


### PR DESCRIPTION
## 개요

Issue #41 작업으로 사용자 친화적인 에러 메시지로 개선합니다.

## 작업 내용

- [x] Scanner: 경로 접근 에러에 파일 경로 포함
- [x] Extractor: 파일 경로 포함, supported languages 목록
- [x] Parser: 언어 설정 에러에 더 상세한 맥락 추가
- [x] Warning 메시지에 해결 방법 제안

- [x] 모든 에러에 %w 래핑 사용하여 원본 에러 보존

## 개선 예시
Before: `permission denied: /path/to/file`
After: `permission denied: /path/to/file (check file permissions or run with appropriate privileges)`

Before: `no parser for language: xyz`
After: `no parser for language "xyz" in "file.go". Supported languages: go, typescript, javascript, python, java, rust, cpp, c, csharp, swift, kotlin, lua, shell, php, ruby, scala`

## 테스트
```bash
go test ./pkg/scanner/... ./pkg/extractor/... ./pkg/parser/...
```

Closes #41