### PR TITLE
perf: buildGlobalImports 정렬을 sort.Slice로 개선

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -2,6 +2,8 @@
 package context
 
 import (
+	"sort"
+
 	"github.com/indigo-net/Brf.it/pkg/extractor"
 	"github.com/indigo-net/Brf.it/pkg/formatter"
 	"github.com/indigo-net/Brf.it/pkg/scanner"
@@ -275,14 +277,12 @@ func buildGlobalImports(files []formatter.FileData) []formatter.ImportCount {
 	}
 
 	// Sort by count descending, then by import string for stability
-	for i := 0; i < len(result); i++ {
-		for j := i + 1; j < len(result); j++ {
-			if result[j].Count > result[i].Count ||
-				(result[j].Count == result[i].Count && result[j].Import < result[i].Import) {
-				result[i], result[j] = result[j], result[i]
-			}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
 		}
-	}
+		return result[i].Import < result[j].Import
+	})
 
 	return result
 }


### PR DESCRIPTION
## Summary
- `buildGlobalImports()`의 O(n²) 버블 정렬을 `sort.Slice()` O(n log n)으로 교체
- 동일한 정렬 기준 유지 (count 내림차순 → import 문자열 오름차순)

Closes #162

## Test plan
- [x] `go test ./...` 전체 통과
- [x] `internal/context` 패키지 테스트 통과
- [x] 기존 정렬 결과와 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)