### PR TITLE
perf: treeNode 리프 노드 map 할당 최적화

### DIFF
--- a/internal/context/tree.go
+++ b/internal/context/tree.go
@@ -18,7 +18,7 @@ func BuildTree(root string, paths []string) string {
 		return ""
 	}
 
-	rootNode := &treeNode{children: make(map[string]*treeNode)}
+	rootNode := &treeNode{}
 
 	// Insert all paths into the tree
 	for _, path := range paths {
@@ -31,10 +31,11 @@ func BuildTree(root string, paths []string) string {
 		current := rootNode
 
 		for _, part := range parts {
+			if current.children == nil {
+				current.children = make(map[string]*treeNode)
+			}
 			if _, exists := current.children[part]; !exists {
-				current.children[part] = &treeNode{
-					children: make(map[string]*treeNode),
-				}
+				current.children[part] = &treeNode{}
 			}
 			current = current.children[part]
 		}


### PR DESCRIPTION
## Summary
- treeNode의 children map을 nil로 초기화, 자식 추가 시에만 lazy 할당
- 리프 노드(파일)에서 불필요한 빈 map 할당 제거
- `len(nil map) == 0`, `range nil map`은 Go에서 안전

Closes #168

## Test plan
- [x] `go test ./...` 전체 통과
- [x] `internal/context` 테스트 통과 (트리 출력 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)