### PR TITLE
docs: GoDoc Example 테스트 함수 추가

### DIFF
--- a/pkg/extractor/example_test.go
+++ b/pkg/extractor/example_test.go
@@ -1,0 +1,18 @@
+package extractor_test
+
+import (
+	"fmt"
+
+	"github.com/indigo-net/Brf.it/pkg/extractor"
+)
+
+func ExampleDefaultExtractOptions() {
+	opts := extractor.DefaultExtractOptions()
+	fmt.Println(opts.Concurrency)
+	fmt.Println(opts.IncludePrivate)
+	fmt.Println(opts.IncludeBody)
+	// Output:
+	// 0
+	// false
+	// false
+}

--- a/pkg/formatter/example_test.go
+++ b/pkg/formatter/example_test.go
@@ -1,0 +1,50 @@
+package formatter_test
+
+import (
+	"fmt"
+
+	"github.com/indigo-net/Brf.it/pkg/formatter"
+)
+
+func ExampleNewXMLFormatter() {
+	f := formatter.NewXMLFormatter()
+	fmt.Println(f.Name())
+	// Output:
+	// xml
+}
+
+func ExampleNewMarkdownFormatter() {
+	f := formatter.NewMarkdownFormatter()
+	fmt.Println(f.Name())
+	// Output:
+	// markdown
+}
+
+func ExampleNewJSONFormatter() {
+	f := formatter.NewJSONFormatter()
+	fmt.Println(f.Name())
+	// Output:
+	// json
+}
+
+func ExampleXMLFormatter_Format() {
+	f := formatter.NewXMLFormatter()
+	data := &formatter.PackageData{
+		RootPath: "/project",
+		Version:  "1.0.0",
+		Files: []formatter.FileData{
+			{
+				Path:     "main.go",
+				Language: "go",
+			},
+		},
+	}
+	output, err := f.Format(data)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(len(output) > 0)
+	// Output:
+	// true
+}

--- a/pkg/parser/example_test.go
+++ b/pkg/parser/example_test.go
@@ -1,0 +1,26 @@
+package parser_test
+
+import (
+	"fmt"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+func ExampleDetectLanguage() {
+	fmt.Println(parser.DetectLanguage("main.go"))
+	fmt.Println(parser.DetectLanguage("app.tsx"))
+	fmt.Println(parser.DetectLanguage("script.py"))
+	fmt.Println(parser.DetectLanguage("unknown.xyz"))
+	// Output:
+	// go
+	// tsx
+	// python
+	//
+}
+
+func ExampleNewRegistry() {
+	reg := parser.NewRegistry()
+	fmt.Println(len(reg.Languages()))
+	// Output:
+	// 0
+}

--- a/pkg/scanner/example_test.go
+++ b/pkg/scanner/example_test.go
@@ -1,0 +1,24 @@
+package scanner_test
+
+import (
+	"fmt"
+
+	"github.com/indigo-net/Brf.it/pkg/scanner"
+)
+
+func ExampleDefaultScanOptions() {
+	opts := scanner.DefaultScanOptions()
+	fmt.Println(opts.MaxFileSize)
+	fmt.Println(opts.IncludeHidden)
+	// Output:
+	// 512000
+	// false
+}
+
+func ExampleIsHidden() {
+	fmt.Println(scanner.IsHidden(".gitignore"))
+	fmt.Println(scanner.IsHidden("main.go"))
+	// Output:
+	// true
+	// false
+}

--- a/pkg/tokenizer/example_test.go
+++ b/pkg/tokenizer/example_test.go
@@ -1,0 +1,18 @@
+package tokenizer_test
+
+import (
+	"fmt"
+
+	"github.com/indigo-net/Brf.it/pkg/tokenizer"
+)
+
+func ExampleNewNoOpTokenizer() {
+	t := tokenizer.NewNoOpTokenizer()
+	fmt.Println(t.Name())
+
+	count, err := t.Count("hello world")
+	fmt.Println(count, err)
+	// Output:
+	// noop
+	// 0 <nil>
+}


### PR DESCRIPTION
## Summary
- 5개 공개 패키지(parser, scanner, extractor, formatter, tokenizer)에 GoDoc Example 테스트 함수 10개 추가
- pkg.go.dev에서 API 사용 예시가 렌더링되도록 함
- `ExampleDetectLanguage`, `ExampleIsHidden`, `ExampleDefaultExtractOptions`, `ExampleXMLFormatter_Format` 등

Closes #43

## Test plan
- [x] `go test ./... -run Example` — 10개 Example 테스트 모두 통과
- [x] `go test ./...` — 전체 테스트 스위트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)