### PR TITLE
fix: extractFile에 context 전달하여 취소 반응 개선

### DIFF
--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -163,7 +163,7 @@ func (e *FileExtractor) Extract(ctx context.Context, scanResult *scanner.ScanRes
 		go func(idx int, entry scanner.FileEntry) {
 			defer wg.Done()
 			defer func() { <-sem }() // Release
-			extracted[idx] = e.extractFile(entry, opts)
+			extracted[idx] = e.extractFile(ctx, entry, opts)
 		}(i, fileEntry)
 	}
 	wg.Wait()
@@ -193,7 +193,7 @@ func (e *FileExtractor) extractSequential(ctx context.Context, files []scanner.F
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		extracted := e.extractFile(fileEntry, opts)
+		extracted := e.extractFile(ctx, fileEntry, opts)
 		result.Files = append(result.Files, extracted)
 		result.TotalSignatures += len(extracted.Signatures)
 		result.TotalSize += extracted.Size
@@ -218,11 +218,17 @@ func isBinaryContent(content []byte) bool {
 }
 
 // extractFile extracts signatures from a single file.
-func (e *FileExtractor) extractFile(entry scanner.FileEntry, opts *ExtractOptions) ExtractedFile {
+func (e *FileExtractor) extractFile(ctx context.Context, entry scanner.FileEntry, opts *ExtractOptions) ExtractedFile {
 	extracted := ExtractedFile{
 		Path:     entry.Path,
 		Language: entry.Language,
 		Size:     entry.Size,
+	}
+
+	// Check context before expensive I/O
+	if err := ctx.Err(); err != nil {
+		extracted.Error = err
+		return extracted
 	}
 
 	// Get parser for language


### PR DESCRIPTION
## Summary
- extractFile 메서드에 context.Context 파라미터 추가
- 파일 I/O 전 ctx.Err() 체크로 취소된 context에서 즉시 반환
- 동시 경로와 순차 경로 모두 ctx 전달

Closes #194

## Test plan
- [x] 기존 extractor 테스트 전체 통과
- [x] TestExtractCanceledContext, TestExtractDeadlineExceededContext 통과
- [x] 전체 프로젝트 테스트 통과