### PR TITLE
fix: captureNames 인덱스 접근 시 방어적 범위 검증 추가

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -252,6 +252,9 @@ func (p *TreeSitterParser) extractSignatures(
 		var kindNode *sitter.Node
 
 		for _, capture := range match.Captures {
+			if int(capture.Index) >= len(captureNames) {
+				continue
+			}
 			name := captureNames[capture.Index]
 			node := capture.Node
 
@@ -1676,6 +1679,9 @@ func (p *TreeSitterParser) extractImports(
 		var importNode *sitter.Node
 
 		for _, capture := range match.Captures {
+			if int(capture.Index) >= len(captureNames) {
+				continue
+			}
 			name := captureNames[capture.Index]
 			node := capture.Node
 			start, end := node.StartByte(), node.EndByte()


### PR DESCRIPTION
## Summary
- 시그니처 추출 캡처 루프에서 `captureNames[capture.Index]` 접근 전 범위 검증 추가
- import 추출 캡처 루프에서도 동일한 가드 추가
- CGO 경계 이상 시 panic 대신 안전하게 skip

Closes #196

## Test plan
- [x] 전체 프로젝트 테스트 통과 (11개 패키지)
- [x] tree-sitter 파서 테스트 통과
- [x] 기존 동작에 영향 없음 (정상 케이스에서 가드 조건 미충족)