### PR TITLE
refactor: BaseQuery 임베딩으로 Captures() 중복 구현 제거

### DIFF
--- a/pkg/parser/treesitter/languages/base.go
+++ b/pkg/parser/treesitter/languages/base.go
@@ -1,0 +1,15 @@
+package languages
+
+// BaseQuery provides default implementations for common LanguageQuery methods.
+// Embed this struct to get the default Captures() implementation.
+type BaseQuery struct{}
+
+// Captures returns the standard capture names used across all language queries.
+func (BaseQuery) Captures() []string {
+	return []string{
+		captureName,
+		captureSignature,
+		captureDoc,
+		captureKind,
+	}
+}

--- a/pkg/parser/treesitter/languages/c.go
+++ b/pkg/parser/treesitter/languages/c.go
@@ -8,6 +8,7 @@ import (
 
 // CQuery implements LanguageQuery for C language.
 type CQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *CQuery) Language() *sitter.Language {
 // Query returns the C query pattern.
 func (q *CQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for C queries.
-func (q *CQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/cpp.go
+++ b/pkg/parser/treesitter/languages/cpp.go
@@ -8,6 +8,7 @@ import (
 
 // CppQuery implements LanguageQuery for C++ language.
 type CppQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *CppQuery) Language() *sitter.Language {
 // Query returns the C++ query pattern.
 func (q *CppQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for C++ queries.
-func (q *CppQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/csharp.go
+++ b/pkg/parser/treesitter/languages/csharp.go
@@ -8,6 +8,7 @@ import (
 
 // CSharpQuery implements LanguageQuery for C# language.
 type CSharpQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *CSharpQuery) Language() *sitter.Language {
 // Query returns the C# query pattern.
 func (q *CSharpQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for C# queries.
-func (q *CSharpQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/elixir.go
+++ b/pkg/parser/treesitter/languages/elixir.go
@@ -8,6 +8,7 @@ import (
 
 // ElixirQuery implements LanguageQuery for Elixir language.
 type ElixirQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *ElixirQuery) Language() *sitter.Language {
 // Query returns the Elixir query pattern.
 func (q *ElixirQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Elixir queries.
-func (q *ElixirQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/go.go
+++ b/pkg/parser/treesitter/languages/go.go
@@ -16,6 +16,7 @@ const (
 
 // GoQuery implements LanguageQuery for Go language.
 type GoQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -36,16 +37,6 @@ func (q *GoQuery) Language() *sitter.Language {
 // Query returns the Go query pattern.
 func (q *GoQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Go queries.
-func (q *GoQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/java.go
+++ b/pkg/parser/treesitter/languages/java.go
@@ -8,6 +8,7 @@ import (
 
 // JavaQuery implements LanguageQuery for Java language.
 type JavaQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *JavaQuery) Language() *sitter.Language {
 // Query returns the Java query pattern.
 func (q *JavaQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Java queries.
-func (q *JavaQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/kotlin.go
+++ b/pkg/parser/treesitter/languages/kotlin.go
@@ -8,6 +8,7 @@ import (
 
 // KotlinQuery implements LanguageQuery for Kotlin language.
 type KotlinQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *KotlinQuery) Language() *sitter.Language {
 // Query returns the Kotlin query pattern.
 func (q *KotlinQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Kotlin queries.
-func (q *KotlinQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/lua.go
+++ b/pkg/parser/treesitter/languages/lua.go
@@ -8,6 +8,7 @@ import (
 
 // LuaQuery implements LanguageQuery for Lua language.
 type LuaQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *LuaQuery) Language() *sitter.Language {
 // Query returns the Lua query pattern.
 func (q *LuaQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Lua queries.
-func (q *LuaQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/php.go
+++ b/pkg/parser/treesitter/languages/php.go
@@ -8,6 +8,7 @@ import (
 
 // PHPQuery implements LanguageQuery for PHP language.
 type PHPQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *PHPQuery) Language() *sitter.Language {
 // Query returns the PHP query pattern.
 func (q *PHPQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for PHP queries.
-func (q *PHPQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/python.go
+++ b/pkg/parser/treesitter/languages/python.go
@@ -7,6 +7,7 @@ import (
 
 // PythonQuery implements LanguageQuery for Python language.
 type PythonQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -27,16 +28,6 @@ func (q *PythonQuery) Language() *sitter.Language {
 // Query returns the Python query pattern.
 func (q *PythonQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Python queries.
-func (q *PythonQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/ruby.go
+++ b/pkg/parser/treesitter/languages/ruby.go
@@ -7,6 +7,7 @@ import (
 
 // RubyQuery implements LanguageQuery for Ruby language.
 type RubyQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -27,16 +28,6 @@ func (q *RubyQuery) Language() *sitter.Language {
 // Query returns the Ruby query pattern.
 func (q *RubyQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Ruby queries.
-func (q *RubyQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/rust.go
+++ b/pkg/parser/treesitter/languages/rust.go
@@ -8,6 +8,7 @@ import (
 
 // RustQuery implements LanguageQuery for Rust language.
 type RustQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *RustQuery) Language() *sitter.Language {
 // Query returns the Rust query pattern.
 func (q *RustQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Rust queries.
-func (q *RustQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/scala.go
+++ b/pkg/parser/treesitter/languages/scala.go
@@ -8,6 +8,7 @@ import (
 
 // ScalaQuery implements LanguageQuery for Scala language.
 type ScalaQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *ScalaQuery) Language() *sitter.Language {
 // Query returns the Scala query pattern.
 func (q *ScalaQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Scala queries.
-func (q *ScalaQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/shell.go
+++ b/pkg/parser/treesitter/languages/shell.go
@@ -8,6 +8,7 @@ import (
 
 // ShellQuery implements LanguageQuery for Shell/Bash language.
 type ShellQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *ShellQuery) Language() *sitter.Language {
 // Query returns the Shell/Bash query pattern.
 func (q *ShellQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Shell/Bash queries.
-func (q *ShellQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/sql.go
+++ b/pkg/parser/treesitter/languages/sql.go
@@ -8,6 +8,7 @@ import (
 
 // SQLQuery implements LanguageQuery for SQL language.
 type SQLQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *SQLQuery) Language() *sitter.Language {
 // Query returns the SQL query pattern.
 func (q *SQLQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for SQL queries.
-func (q *SQLQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from SQL DDL node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/swift.go
+++ b/pkg/parser/treesitter/languages/swift.go
@@ -8,6 +8,7 @@ import (
 
 // SwiftQuery implements LanguageQuery for Swift language.
 type SwiftQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -28,16 +29,6 @@ func (q *SwiftQuery) Language() *sitter.Language {
 // Query returns the Swift query pattern.
 func (q *SwiftQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for Swift queries.
-func (q *SwiftQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.

--- a/pkg/parser/treesitter/languages/typescript.go
+++ b/pkg/parser/treesitter/languages/typescript.go
@@ -7,6 +7,7 @@ import (
 
 // TypeScriptQuery implements LanguageQuery for TypeScript language.
 type TypeScriptQuery struct {
+	BaseQuery
 	language *sitter.Language
 	query    []byte
 }
@@ -27,16 +28,6 @@ func (q *TypeScriptQuery) Language() *sitter.Language {
 // Query returns the TypeScript query pattern.
 func (q *TypeScriptQuery) Query() []byte {
 	return q.query
-}
-
-// Captures returns the capture names for TypeScript queries.
-func (q *TypeScriptQuery) Captures() []string {
-	return []string{
-		captureName,
-		captureSignature,
-		captureDoc,
-		captureKind,
-	}
 }
 
 // KindMapping returns the mapping from node types to Signature kinds.


### PR DESCRIPTION
## Summary
- 17개 언어 파일의 동일한 `Captures()` 메서드를 `BaseQuery` 구조체 임베딩으로 통합
- `base.go`에 `BaseQuery` 구조체와 기본 `Captures()` 구현 추가
- 각 언어 쿼리 구조체에 `BaseQuery` 임베딩하여 개별 `Captures()` 메서드 제거
- 170줄 삭제, 32줄 추가 (net -138줄)

Closes #198

## Test plan
- [x] 전체 빌드 통과 (`go build ./...`)
- [x] treesitter 패키지 테스트 통과 (`go test ./pkg/parser/treesitter/...`)
- [x] 각 언어별 TestXxxQueryCaptures 테스트 통과 (임베딩된 메서드 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)