### PR TITLE
fix: 하드코딩 언어 목록을 Registry 동적 조회로 교체

### DIFF
--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/indigo-net/Brf.it/pkg/parser"
@@ -234,7 +236,9 @@ func (e *FileExtractor) extractFile(ctx context.Context, entry scanner.FileEntry
 	// Get parser for language
 	p, ok := e.registry.Get(entry.Language)
 	if !ok {
-		extracted.Error = fmt.Errorf("no parser for language %q in %q. Available parsers: go, typescript, tsx, javascript, jsx, python, c, java, cpp, rust, swift, kotlin, csharp, lua, shell, php, ruby, scala", entry.Language, entry.Path)
+		langs := e.registry.Languages()
+		sort.Strings(langs)
+		extracted.Error = fmt.Errorf("no parser for language %q in %q. Available parsers: %s", entry.Language, entry.Path, strings.Join(langs, ", "))
 		return extracted
 	}
 


### PR DESCRIPTION
## Summary
- `extractor.go`의 하드코딩된 `Available parsers` 에러 메시지를 `Registry.Languages()` 동적 조회로 교체
- `sort.Strings`로 정렬하여 일관된 출력 보장
- 새 언어 추가 시 에러 메시지가 자동 반영됨 (SSOT 보장)

Closes #183

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] 빌드 성공 (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)