### PR TITLE
refactor: sync.Map + RWMutex 이중 잠금을 sync.Map 단독으로 단순화

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -56,7 +56,6 @@ type queryCacheKey struct {
 type TreeSitterParser struct {
 	queries         map[string]LanguageQuery
 	compiledQueries sync.Map // map[queryCacheKey]*sitter.Query
-	queryCacheMutex sync.RWMutex
 	parserPool      sync.Pool
 	cursorPool      sync.Pool
 }
@@ -105,24 +104,12 @@ func NewTreeSitterParser() *TreeSitterParser {
 func (p *TreeSitterParser) getOrCreateQuery(lang string, langQuery LanguageQuery, typ queryType) (*sitter.Query, error) {
 	key := queryCacheKey{lang: lang, typ: typ}
 
-	// Fast path: check cache with read lock
-	p.queryCacheMutex.RLock()
-	if cached, ok := p.compiledQueries.Load(key); ok {
-		p.queryCacheMutex.RUnlock()
-		return cached.(*sitter.Query), nil
-	}
-	p.queryCacheMutex.RUnlock()
-
-	// Slow path: create query with write lock
-	p.queryCacheMutex.Lock()
-	defer p.queryCacheMutex.Unlock()
-
-	// Double-check after acquiring write lock
+	// Fast path: check cache (sync.Map is inherently thread-safe)
 	if cached, ok := p.compiledQueries.Load(key); ok {
 		return cached.(*sitter.Query), nil
 	}
 
-	// Create new query
+	// Slow path: create query and attempt to store it
 	var queryStr string
 	if typ == queryTypeSignature {
 		queryStr = string(langQuery.Query())
@@ -135,7 +122,13 @@ func (p *TreeSitterParser) getOrCreateQuery(lang string, langQuery LanguageQuery
 		return nil, err
 	}
 
-	p.compiledQueries.Store(key, query)
+	// LoadOrStore ensures only one query per key is retained.
+	// If another goroutine won the race, close our duplicate and use theirs.
+	actual, loaded := p.compiledQueries.LoadOrStore(key, query)
+	if loaded {
+		query.Close()
+		return actual.(*sitter.Query), nil
+	}
 	return query, nil
 }
 


### PR DESCRIPTION
## Summary
- `queryCacheMutex` (sync.RWMutex) 제거, `sync.Map` 단독 사용으로 단순화
- `LoadOrStore` 패턴으로 경합 시 중복 Query를 `Close()`로 안전 해제
- `go test -race` 통과 확인

Closes #182

## Test plan
- [x] `go test -race ./pkg/parser/treesitter/...` 통과
- [x] 전체 테스트 통과 (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)