### PR TITLE
refactor: init()에서 TreeSitterParser 단일 인스턴스 공유로 변경

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -11,28 +11,14 @@ import (
 	"github.com/indigo-net/Brf.it/pkg/parser/treesitter/languages"
 )
 
-// init registers the TreeSitterParser with the default registry.
+// init registers a single shared TreeSitterParser with the default registry.
+// One instance handles all languages via its internal query map, sharing
+// sync.Pool resources (parsers, cursors) across languages for better reuse.
 func init() {
-	parser.RegisterParser("go", NewTreeSitterParser())
-	parser.RegisterParser("typescript", NewTreeSitterParser())
-	parser.RegisterParser("tsx", NewTreeSitterParser())
-	parser.RegisterParser("javascript", NewTreeSitterParser())
-	parser.RegisterParser("jsx", NewTreeSitterParser())
-	parser.RegisterParser("python", NewTreeSitterParser())
-	parser.RegisterParser("c", NewTreeSitterParser())
-	parser.RegisterParser("java", NewTreeSitterParser())
-	parser.RegisterParser("cpp", NewTreeSitterParser())
-	parser.RegisterParser("rust", NewTreeSitterParser())
-	parser.RegisterParser("swift", NewTreeSitterParser())
-	parser.RegisterParser("kotlin", NewTreeSitterParser())
-	parser.RegisterParser("csharp", NewTreeSitterParser())
-	parser.RegisterParser("lua", NewTreeSitterParser())
-	parser.RegisterParser("shell", NewTreeSitterParser())
-	parser.RegisterParser("php", NewTreeSitterParser())
-	parser.RegisterParser("ruby", NewTreeSitterParser())
-	parser.RegisterParser("scala", NewTreeSitterParser())
-	parser.RegisterParser("elixir", NewTreeSitterParser())
-	parser.RegisterParser("sql", NewTreeSitterParser())
+	p := NewTreeSitterParser()
+	for lang := range p.queries {
+		parser.RegisterParser(lang, p)
+	}
 }
 
 // queryType distinguishes between signature and import queries for caching.


### PR DESCRIPTION
## Summary
- `init()`에서 20개 독립 `NewTreeSitterParser()` 인스턴스를 단일 공유 인스턴스로 변경
- `p.queries` 맵을 순회하여 동적으로 언어 등록 (새 언어 추가 시 자동 반영)
- `sync.Pool` (파서, 커서) 재사용 효율 20배 개선

Closes #181

## Test plan
- [x] `go test -race ./...` 전체 통과
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)