### PR TITLE
perf: KindMapping() 결과를 패키지 수준 변수로 캐싱

### DIFF
--- a/pkg/parser/treesitter/languages/c.go
+++ b/pkg/parser/treesitter/languages/c.go
@@ -31,18 +31,20 @@ func (q *CQuery) Query() []byte {
 	return q.query
 }
 
+var cKindMapping = map[string]string{
+	"function_definition":  "function",
+	"declaration":          "function", // function prototypes
+	"struct_specifier":     "struct",
+	"enum_specifier":       "enum",
+	"type_definition":      "typedef",
+	"preproc_function_def": "macro",
+	"preproc_def":          "macro",
+	"global_variable":      "variable", // mapped from declaration patterns
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *CQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_definition":  "function",
-		"declaration":          "function", // function prototypes
-		"struct_specifier":     "struct",
-		"enum_specifier":       "enum",
-		"type_definition":      "typedef",
-		"preproc_function_def": "macro",
-		"preproc_def":          "macro",
-		"global_variable":      "variable", // mapped from declaration patterns
-	}
+	return cKindMapping
 }
 
 // ImportQuery returns the C import query pattern.

--- a/pkg/parser/treesitter/languages/cpp.go
+++ b/pkg/parser/treesitter/languages/cpp.go
@@ -31,21 +31,23 @@ func (q *CppQuery) Query() []byte {
 	return q.query
 }
 
+var cppKindMapping = map[string]string{
+	"function_definition":  "function",
+	"declaration":          "function",
+	"struct_specifier":     "struct",
+	"enum_specifier":       "enum",
+	"type_definition":      "typedef",
+	"preproc_function_def": "macro",
+	"preproc_def":          "macro",
+	"class_specifier":      "class",
+	"field_declaration":    "method",
+	"template_declaration": "template",
+	"namespace_definition": "namespace",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *CppQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_definition":  "function",
-		"declaration":          "function",
-		"struct_specifier":     "struct",
-		"enum_specifier":       "enum",
-		"type_definition":      "typedef",
-		"preproc_function_def": "macro",
-		"preproc_def":          "macro",
-		"class_specifier":      "class",
-		"field_declaration":    "method",
-		"template_declaration": "template",
-		"namespace_definition": "namespace",
-	}
+	return cppKindMapping
 }
 
 // ImportQuery returns the C++ import query pattern.

--- a/pkg/parser/treesitter/languages/csharp.go
+++ b/pkg/parser/treesitter/languages/csharp.go
@@ -31,29 +31,31 @@ func (q *CSharpQuery) Query() []byte {
 	return q.query
 }
 
+var csharpKindMapping = map[string]string{
+	"class_declaration":                 "class",
+	"struct_declaration":                "struct",
+	"interface_declaration":             "interface",
+	"enum_declaration":                  "enum",
+	"record_declaration":                "record",
+	"delegate_declaration":              "type",
+	"method_declaration":                "method",
+	"constructor_declaration":           "constructor",
+	"destructor_declaration":            "destructor",
+	"property_declaration":              "variable",
+	"field_declaration":                 "field",
+	"event_declaration":                 "variable",
+	"event_field_declaration":           "variable",
+	"indexer_declaration":               "method",
+	"operator_declaration":              "function",
+	"conversion_operator_declaration":   "function",
+	"namespace_declaration":             "namespace",
+	"file_scoped_namespace_declaration": "namespace",
+	"enum_member_declaration":           "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *CSharpQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"class_declaration":                 "class",
-		"struct_declaration":                "struct",
-		"interface_declaration":             "interface",
-		"enum_declaration":                  "enum",
-		"record_declaration":                "record",
-		"delegate_declaration":              "type",
-		"method_declaration":                "method",
-		"constructor_declaration":           "constructor",
-		"destructor_declaration":            "destructor",
-		"property_declaration":              "variable",
-		"field_declaration":                 "field",
-		"event_declaration":                 "variable",
-		"event_field_declaration":           "variable",
-		"indexer_declaration":               "method",
-		"operator_declaration":              "function",
-		"conversion_operator_declaration":   "function",
-		"namespace_declaration":             "namespace",
-		"file_scoped_namespace_declaration": "namespace",
-		"enum_member_declaration":           "variable",
-	}
+	return csharpKindMapping
 }
 
 // ImportQuery returns the C# import query pattern.

--- a/pkg/parser/treesitter/languages/elixir.go
+++ b/pkg/parser/treesitter/languages/elixir.go
@@ -31,14 +31,16 @@ func (q *ElixirQuery) Query() []byte {
 	return q.query
 }
 
+var elixirKindMapping = map[string]string{
+	"call":           "function",
+	"unary_operator": "type",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 // Elixir uses generic node types (call, unary_operator) which are refined
 // on the Go side in parser.go based on the signature text.
 func (q *ElixirQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"call":           "function",
-		"unary_operator": "type",
-	}
+	return elixirKindMapping
 }
 
 // ImportQuery returns the Elixir import query pattern.

--- a/pkg/parser/treesitter/languages/go.go
+++ b/pkg/parser/treesitter/languages/go.go
@@ -39,17 +39,19 @@ func (q *GoQuery) Query() []byte {
 	return q.query
 }
 
+var goKindMapping = map[string]string{
+	"function_declaration": "function",
+	"method_declaration":   "method",
+	"type_declaration":     "type",
+	"const_declaration":    "variable",
+	"var_declaration":      "variable",
+	"const_spec":           "variable",
+	"var_spec":             "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *GoQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_declaration": "function",
-		"method_declaration":   "method",
-		"type_declaration":     "type",
-		"const_declaration":    "variable",
-		"var_declaration":      "variable",
-		"const_spec":           "variable",
-		"var_spec":             "variable",
-	}
+	return goKindMapping
 }
 
 // ImportQuery returns the Go import query pattern.

--- a/pkg/parser/treesitter/languages/java.go
+++ b/pkg/parser/treesitter/languages/java.go
@@ -31,18 +31,20 @@ func (q *JavaQuery) Query() []byte {
 	return q.query
 }
 
+var javaKindMapping = map[string]string{
+	"class_declaration":           "class",
+	"interface_declaration":       "interface",
+	"method_declaration":          "method",
+	"constructor_declaration":     "constructor",
+	"enum_declaration":            "enum",
+	"annotation_type_declaration": "annotation",
+	"record_declaration":          "record",
+	"field_declaration":           "field",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *JavaQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"class_declaration":           "class",
-		"interface_declaration":       "interface",
-		"method_declaration":          "method",
-		"constructor_declaration":     "constructor",
-		"enum_declaration":            "enum",
-		"annotation_type_declaration": "annotation",
-		"record_declaration":          "record",
-		"field_declaration":           "field",
-	}
+	return javaKindMapping
 }
 
 // ImportQuery returns the Java import query pattern.

--- a/pkg/parser/treesitter/languages/kotlin.go
+++ b/pkg/parser/treesitter/languages/kotlin.go
@@ -31,18 +31,20 @@ func (q *KotlinQuery) Query() []byte {
 	return q.query
 }
 
+var kotlinKindMapping = map[string]string{
+	"function_declaration":  "function",
+	"class_declaration":     "class",
+	"object_declaration":    "class",
+	"companion_object":      "class",
+	"property_declaration":  "variable",
+	"type_alias":            "type",
+	"enum_entry":            "variable",
+	"secondary_constructor": "constructor",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *KotlinQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_declaration":  "function",
-		"class_declaration":     "class",
-		"object_declaration":    "class",
-		"companion_object":      "class",
-		"property_declaration":  "variable",
-		"type_alias":            "type",
-		"enum_entry":            "variable",
-		"secondary_constructor": "constructor",
-	}
+	return kotlinKindMapping
 }
 
 // ImportQuery returns the Kotlin import query pattern.

--- a/pkg/parser/treesitter/languages/lua.go
+++ b/pkg/parser/treesitter/languages/lua.go
@@ -31,13 +31,15 @@ func (q *LuaQuery) Query() []byte {
 	return q.query
 }
 
+var luaKindMapping = map[string]string{
+	"function_declaration": "function",
+	"variable_declaration": "variable",
+	"assignment_statement": "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *LuaQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_declaration": "function",
-		"variable_declaration": "variable",
-		"assignment_statement": "variable",
-	}
+	return luaKindMapping
 }
 
 // ImportQuery returns the Lua import query pattern.

--- a/pkg/parser/treesitter/languages/php.go
+++ b/pkg/parser/treesitter/languages/php.go
@@ -31,19 +31,21 @@ func (q *PHPQuery) Query() []byte {
 	return q.query
 }
 
+var phpKindMapping = map[string]string{
+	"function_definition":       "function",
+	"method_declaration":        "method",
+	"class_declaration":         "class",
+	"interface_declaration":     "interface",
+	"trait_declaration":         "type",
+	"enum_declaration":          "enum",
+	"const_declaration":         "variable",
+	"property_declaration":      "variable",
+	"namespace_use_declaration": "import",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *PHPQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_definition":       "function",
-		"method_declaration":        "method",
-		"class_declaration":         "class",
-		"interface_declaration":     "interface",
-		"trait_declaration":         "type",
-		"enum_declaration":          "enum",
-		"const_declaration":         "variable",
-		"property_declaration":      "variable",
-		"namespace_use_declaration": "import",
-	}
+	return phpKindMapping
 }
 
 // ImportQuery returns the PHP import query pattern.

--- a/pkg/parser/treesitter/languages/python.go
+++ b/pkg/parser/treesitter/languages/python.go
@@ -30,14 +30,16 @@ func (q *PythonQuery) Query() []byte {
 	return q.query
 }
 
+var pythonKindMapping = map[string]string{
+	"function_definition":  "function",
+	"class_definition":     "class",
+	"expression_statement": "variable",
+	"assignment":           "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *PythonQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_definition":  "function",
-		"class_definition":     "class",
-		"expression_statement": "variable",
-		"assignment":           "variable",
-	}
+	return pythonKindMapping
 }
 
 // ImportQuery returns the Python import query pattern.

--- a/pkg/parser/treesitter/languages/ruby.go
+++ b/pkg/parser/treesitter/languages/ruby.go
@@ -30,15 +30,17 @@ func (q *RubyQuery) Query() []byte {
 	return q.query
 }
 
+var rubyKindMapping = map[string]string{
+	"method":           "method",
+	"singleton_method": "method",
+	"class":            "class",
+	"module":           "namespace",
+	"assignment":       "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *RubyQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"method":           "method",
-		"singleton_method": "method",
-		"class":            "class",
-		"module":           "namespace",
-		"assignment":       "variable",
-	}
+	return rubyKindMapping
 }
 
 // ImportQuery returns the Ruby import query pattern.

--- a/pkg/parser/treesitter/languages/rust.go
+++ b/pkg/parser/treesitter/languages/rust.go
@@ -31,24 +31,26 @@ func (q *RustQuery) Query() []byte {
 	return q.query
 }
 
+var rustKindMapping = map[string]string{
+	"function_item":           "function",
+	"struct_item":             "struct",
+	"enum_item":               "enum",
+	"trait_item":              "trait",
+	"type_item":               "type",
+	"impl_item":               "impl",
+	"const_item":              "variable",
+	"static_item":             "variable",
+	"mod_item":                "namespace",
+	"macro_definition":        "macro",
+	"foreign_mod_item":        "namespace",
+	"union_item":              "struct",
+	"associated_type":         "type",
+	"function_signature_item": "function",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *RustQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_item":           "function",
-		"struct_item":             "struct",
-		"enum_item":               "enum",
-		"trait_item":              "trait",
-		"type_item":               "type",
-		"impl_item":               "impl",
-		"const_item":              "variable",
-		"static_item":             "variable",
-		"mod_item":                "namespace",
-		"macro_definition":        "macro",
-		"foreign_mod_item":        "namespace",
-		"union_item":              "struct",
-		"associated_type":         "type",
-		"function_signature_item": "function",
-	}
+	return rustKindMapping
 }
 
 // ImportQuery returns the Rust import query pattern.

--- a/pkg/parser/treesitter/languages/scala.go
+++ b/pkg/parser/treesitter/languages/scala.go
@@ -31,22 +31,24 @@ func (q *ScalaQuery) Query() []byte {
 	return q.query
 }
 
+var scalaKindMapping = map[string]string{
+	"function_definition":  "method",
+	"function_declaration": "method",
+	"class_definition":     "class",
+	"trait_definition":     "trait",
+	"object_definition":    "class",
+	"val_definition":       "variable",
+	"val_declaration":      "variable",
+	"var_definition":       "variable",
+	"var_declaration":      "variable",
+	"type_definition":      "type",
+	"enum_definition":      "enum",
+	"given_definition":     "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *ScalaQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_definition":  "method",
-		"function_declaration": "method",
-		"class_definition":     "class",
-		"trait_definition":     "trait",
-		"object_definition":    "class",
-		"val_definition":       "variable",
-		"val_declaration":      "variable",
-		"var_definition":       "variable",
-		"var_declaration":      "variable",
-		"type_definition":      "type",
-		"enum_definition":      "enum",
-		"given_definition":     "variable",
-	}
+	return scalaKindMapping
 }
 
 // ImportQuery returns the Scala import query pattern.

--- a/pkg/parser/treesitter/languages/shell.go
+++ b/pkg/parser/treesitter/languages/shell.go
@@ -31,12 +31,14 @@ func (q *ShellQuery) Query() []byte {
 	return q.query
 }
 
+var shellKindMapping = map[string]string{
+	"function_definition": "function",
+	"variable_assignment": "variable",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *ShellQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_definition": "function",
-		"variable_assignment": "variable",
-	}
+	return shellKindMapping
 }
 
 // ImportQuery returns the Shell/Bash import query pattern.

--- a/pkg/parser/treesitter/languages/sql.go
+++ b/pkg/parser/treesitter/languages/sql.go
@@ -31,20 +31,22 @@ func (q *SQLQuery) Query() []byte {
 	return q.query
 }
 
+var sqlKindMapping = map[string]string{
+	"create_table":             "struct",
+	"create_function":          "function",
+	"create_view":              "type",
+	"create_materialized_view": "type",
+	"create_index":             "variable",
+	"create_trigger":           "function",
+	"create_type":              "type",
+	"create_schema":            "namespace",
+	"create_sequence":          "variable",
+	"alter_table":              "type",
+}
+
 // KindMapping returns the mapping from SQL DDL node types to Signature kinds.
 func (q *SQLQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"create_table":             "struct",
-		"create_function":          "function",
-		"create_view":              "type",
-		"create_materialized_view": "type",
-		"create_index":             "variable",
-		"create_trigger":           "function",
-		"create_type":              "type",
-		"create_schema":            "namespace",
-		"create_sequence":          "variable",
-		"alter_table":              "type",
-	}
+	return sqlKindMapping
 }
 
 // ImportQuery returns nil since SQL has no import system.

--- a/pkg/parser/treesitter/languages/swift.go
+++ b/pkg/parser/treesitter/languages/swift.go
@@ -31,20 +31,22 @@ func (q *SwiftQuery) Query() []byte {
 	return q.query
 }
 
+var swiftKindMapping = map[string]string{
+	"function_declaration":          "function",
+	"class_declaration":             "class",
+	"protocol_declaration":          "interface",
+	"typealias_declaration":         "type",
+	"property_declaration":          "variable",
+	"init_declaration":              "constructor",
+	"deinit_declaration":            "destructor",
+	"subscript_declaration":         "method",
+	"operator_declaration":          "function",
+	"protocol_function_declaration": "function",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *SwiftQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_declaration":          "function",
-		"class_declaration":             "class",
-		"protocol_declaration":          "interface",
-		"typealias_declaration":         "type",
-		"property_declaration":          "variable",
-		"init_declaration":              "constructor",
-		"deinit_declaration":            "destructor",
-		"subscript_declaration":         "method",
-		"operator_declaration":          "function",
-		"protocol_function_declaration": "function",
-	}
+	return swiftKindMapping
 }
 
 // ImportQuery returns the Swift import query pattern.

--- a/pkg/parser/treesitter/languages/typescript.go
+++ b/pkg/parser/treesitter/languages/typescript.go
@@ -30,20 +30,22 @@ func (q *TypeScriptQuery) Query() []byte {
 	return q.query
 }
 
+var tsKindMapping = map[string]string{
+	"function_declaration":   "function",
+	"method_definition":      "method",
+	"class_declaration":      "class",
+	"interface_declaration":  "interface",
+	"type_alias_declaration": "type",
+	"arrow_function":         "function",
+	"variable_declaration":   "variable",
+	"variable_declarator":    "arrow",
+	"lexical_declaration":    "arrow",
+	"export_statement":       "export",
+}
+
 // KindMapping returns the mapping from node types to Signature kinds.
 func (q *TypeScriptQuery) KindMapping() map[string]string {
-	return map[string]string{
-		"function_declaration":   "function",
-		"method_definition":      "method",
-		"class_declaration":      "class",
-		"interface_declaration":  "interface",
-		"type_alias_declaration": "type",
-		"arrow_function":         "function",
-		"variable_declaration":   "variable",
-		"variable_declarator":    "arrow",
-		"lexical_declaration":    "arrow",
-		"export_statement":       "export",
-	}
+	return tsKindMapping
 }
 
 // ImportQuery returns the TypeScript import query pattern.


### PR DESCRIPTION
## Summary
- 17개 언어의 `KindMapping()` 메서드가 매번 새 map 리터럴을 생성하던 것을 패키지 수준 변수로 캐싱
- 파일 수만큼 발생하던 불필요한 map 할당 제거
- 읽기 전용 map이므로 동시성 안전

Closes #199

## Test plan
- [x] treesitter 패키지 테스트 통과
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)