### PR TITLE
perf: 파서 내 []byte→string 변환 최소화

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -30,6 +30,14 @@ const (
 	queryTypeImport
 )
 
+// elixirDefPrefixes are byte-slice prefixes used to filter out non-import
+// Elixir definitions (defmodule/defprotocol/defimpl) from import queries.
+var elixirDefPrefixes = [][]byte{
+	[]byte("defmodule "),
+	[]byte("defprotocol "),
+	[]byte("defimpl "),
+}
+
 // supportedLangs is the list of languages with Tree-sitter parsers available.
 const supportedLangs = "go, typescript, tsx, javascript, jsx, python, c, java, cpp, rust, swift, kotlin, csharp, lua, shell, php, ruby, scala, elixir, sql"
 
@@ -1636,14 +1644,18 @@ func (p *TreeSitterParser) extractImports(
 			}
 			seenPositions[startByte] = true
 
-			rawBytes := content[startByte:(*importNode).EndByte()]
+			endByte := (*importNode).EndByte()
+			if endByte > uint(len(content)) || startByte > endByte {
+				continue
+			}
+			rawBytes := content[startByte:endByte]
 
 			// Elixir: the broad import query pattern also matches defmodule/defprotocol/defimpl
 			// (since they also take alias arguments). Filter them out on byte slice
 			// to avoid string conversion for skipped entries.
 			if opts.Language == "elixir" {
 				skip := false
-				for _, defKw := range [][]byte{[]byte("defmodule "), []byte("defprotocol "), []byte("defimpl ")} {
+				for _, defKw := range elixirDefPrefixes {
 					if bytes.HasPrefix(rawBytes, defKw) {
 						skip = true
 						break


### PR DESCRIPTION
## Summary
- 시그니처 추출 시 `bytes.TrimSpace`로 바이트 수준 trim 후 한 번만 string 변환 (중간 string 할당 제거)
- import 캡처에서 텍스트 미사용 경우 (`CaptureImportPath`) string 변환 생략
- Elixir import 필터링을 `bytes.HasPrefix`로 변경하여 스킵 항목의 불필요한 string 할당 제거

Closes #200

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)