### PR TITLE
perf: buildGlobalImports seen 맵 재사용으로 할당 감소

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -255,12 +255,13 @@ func normalizeFormat(format string) string {
 func buildGlobalImports(files []formatter.FileData) []formatter.ImportCount {
 	importCounts := make(map[string]int)
 
+	seen := make(map[string]bool)
 	for _, file := range files {
 		if file.Error != nil {
 			continue
 		}
 		// Use a set to count each import only once per file
-		seen := make(map[string]bool)
+		clear(seen)
 		for _, imp := range file.RawImports {
 			if !seen[imp] {
 				seen[imp] = true


### PR DESCRIPTION
## Summary
- `buildGlobalImports()`의 `seen` 맵을 루프 외부로 이동하고 `clear()`로 재사용
- N개 파일 처리 시 N번 맵 할당 → 1번 할당으로 감소

Closes #201

## Test plan
- [x] `go test ./internal/context/...` 통과
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)