### PR TITLE
perf: signatures/imports 슬라이스 초기 용량 힌트 추가

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -207,7 +207,7 @@ func (p *TreeSitterParser) extractSignatures(
 	langQuery LanguageQuery,
 	opts *parser.Options,
 ) ([]parser.Signature, error) {
-	var signatures []parser.Signature
+	signatures := make([]parser.Signature, 0, 32)
 
 	// Get cached query (or create if first time)
 	query, err := p.getOrCreateQuery(opts.Language, langQuery, queryTypeSignature)
@@ -1575,7 +1575,7 @@ func (p *TreeSitterParser) extractImports(
 	langQuery LanguageQuery,
 	opts *parser.Options,
 ) ([]string, error) {
-	var imports []string
+	imports := make([]string, 0, 8)
 
 	importQueryBytes := langQuery.ImportQuery()
 	if importQueryBytes == nil || len(importQueryBytes) == 0 {


### PR DESCRIPTION
## Summary
- `var signatures []parser.Signature` → `make([]parser.Signature, 0, 32)` 변경
- `var imports []string` → `make([]string, 0, 8)` 변경
- 빈번한 슬라이스 grow 연산 감소로 GC 부하 완화

Closes #202

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)