### PR TITLE
perf: Markdown 포매터 불필요한 구분선/줄바꿈 축소로 토큰 절약

### DIFF
--- a/pkg/formatter/markdown.go
+++ b/pkg/formatter/markdown.go
@@ -63,7 +63,6 @@ func (f *MarkdownFormatter) Format(data *PackageData) ([]byte, error) {
 	}
 
 	// Files
-	buf.WriteString("---\n\n")
 	buf.WriteString("## Files\n\n")
 	for _, file := range data.Files {
 		buf.WriteString("### ")
@@ -104,7 +103,7 @@ func (f *MarkdownFormatter) Format(data *PackageData) ([]byte, error) {
 					buf.WriteString("\n")
 				}
 			}
-			buf.WriteString("```\n\n")
+			buf.WriteString("```\n")
 
 			// Add docs as quotes (빈 파일이면 건너뜀)
 			if !isEmpty {
@@ -112,13 +111,13 @@ func (f *MarkdownFormatter) Format(data *PackageData) ([]byte, error) {
 					if sig.Doc != "" {
 						buf.WriteString("> ")
 						buf.WriteString(escapeMarkdown(truncateDoc(sig.Doc, data.MaxDocLength)))
-						buf.WriteString("\n\n")
+						buf.WriteString("\n")
 					}
 				}
 			}
 		}
 
-		buf.WriteString("---\n\n")
+		buf.WriteByte('\n')
 	}
 
 	return buf.Bytes(), nil


### PR DESCRIPTION
## Summary
- Files 섹션 앞 수평선(`---`) 제거 — 헤딩(`## Files`)이 충분한 구분
- 코드블록 후 이중 줄바꿈(`\n\n`) → 단일 줄바꿈으로 변경
- 각 파일 끝 구분선(`---\n\n`) 제거 — `### filename` 헤딩이 구분 역할
- 문서 인용(`>`) 후 이중 줄바꿈 → 단일로 변경

파일 수가 많은 프로젝트에서 출력 토큰 15-20% 절감 기대.

Closes #195

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] Markdown 포매터 테스트 전체 통과 (fuzz 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)