### PR TITLE
feat: Packager.Package()에 context.Context 전파

### DIFF
--- a/cmd/brfit/root.go
+++ b/cmd/brfit/root.go
@@ -187,7 +187,7 @@ func runRoot(cmd *cobra.Command, args []string, c *config.Config) error {
 	opts := c.ToOptions()
 
 	// Execute packaging
-	result, err := packager.Package(opts)
+	result, err := packager.Package(cmd.Context(), opts)
 	if err != nil {
 		return fmt.Errorf("processing failed: %w", err)
 	}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -122,7 +122,7 @@ func (p *Packager) SetTokenizer(t tokenizer.Tokenizer) {
 }
 
 // Package processes files and returns formatted output.
-func (p *Packager) Package(opts *Options) (*Result, error) {
+func (p *Packager) Package(ctx context.Context, opts *Options) (*Result, error) {
 	if opts == nil {
 		opts = DefaultOptions()
 	}
@@ -140,8 +140,7 @@ func (p *Packager) Package(opts *Options) (*Result, error) {
 		IncludeImports: opts.IncludeImports,
 		MaxFileSize:    opts.MaxFileSize,
 	}
-	// TODO: propagate context from Package() caller once Package accepts context.Context
-	extractResult, err := p.extractor.Extract(context.TODO(), scanResult, extractOpts)
+	extractResult, err := p.extractor.Extract(ctx, scanResult, extractOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -74,7 +74,7 @@ func TestPackagerPackage(t *testing.T) {
 
 	p := NewPackager(mockScan, mockExt, formatters)
 
-	result, err := p.Package(&Options{
+	result, err := p.Package(context.Background(), &Options{
 		Path:        ".",
 		Format:      "xml",
 		IncludeTree: false,
@@ -133,7 +133,7 @@ func TestPackagerPackageMarkdown(t *testing.T) {
 	p := NewPackager(mockScan, mockExt, formatters)
 
 	// Test with "md" - should be normalized to "markdown"
-	result, err := p.Package(&Options{
+	result, err := p.Package(context.Background(), &Options{
 		Path:        ".",
 		Format:      "md",
 		IncludeTree: false,
@@ -177,7 +177,7 @@ func TestPackagerPackageMarkdownFull(t *testing.T) {
 	p := NewPackager(mockScan, mockExt, formatters)
 
 	// Test with "markdown" directly
-	result, err := p.Package(&Options{
+	result, err := p.Package(context.Background(), &Options{
 		Path:        ".",
 		Format:      "markdown",
 		IncludeTree: false,
@@ -206,7 +206,7 @@ func TestPackagerUnknownFormat(t *testing.T) {
 
 	p := NewPackager(mockScan, mockExt, formatters)
 
-	result, err := p.Package(&Options{
+	result, err := p.Package(context.Background(), &Options{
 		Format: "unknown",
 	})
 	if err != nil {
@@ -248,7 +248,7 @@ func TestPackagerSetTokenizer(t *testing.T) {
 	p := NewPackager(mockScan, mockExt, formatters)
 
 	// Default: NoOpTokenizer
-	result, err := p.Package(&Options{Format: "xml"})
+	result, err := p.Package(context.Background(), &Options{Format: "xml"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestPackagerSetTokenizer(t *testing.T) {
 
 	// Set nil tokenizer (should use NoOpTokenizer)
 	p.SetTokenizer(nil)
-	result, err = p.Package(&Options{Format: "xml"})
+	result, err = p.Package(context.Background(), &Options{Format: "xml"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +302,7 @@ func TestPackagerWithTiktokenTokenizer(t *testing.T) {
 	}
 	p.SetTokenizer(tt)
 
-	result, err := p.Package(&Options{Format: "xml"})
+	result, err := p.Package(context.Background(), &Options{Format: "xml"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,8 +348,8 @@ func TestPackagerTokenizerConsistency(t *testing.T) {
 	p.SetTokenizer(tt)
 
 	// Multiple calls should return consistent token counts
-	result1, _ := p.Package(&Options{Format: "xml"})
-	result2, _ := p.Package(&Options{Format: "xml"})
+	result1, _ := p.Package(context.Background(), &Options{Format: "xml"})
+	result2, _ := p.Package(context.Background(), &Options{Format: "xml"})
 
 	if result1.TokenCount != result2.TokenCount {
 		t.Errorf("inconsistent token counts: %d vs %d", result1.TokenCount, result2.TokenCount)
@@ -469,7 +469,7 @@ func TestPackagerNoStdImportsPassthrough(t *testing.T) {
 	p := NewPackager(mockScan, mockExt, formatters)
 
 	// With IncludeImports=true, imports should be included verbatim
-	result, err := p.Package(&Options{
+	result, err := p.Package(context.Background(), &Options{
 		Path:           ".",
 		Format:         "xml",
 		IncludeTree:    false,


### PR DESCRIPTION
## Summary
- `Package(opts *Options)` → `Package(ctx context.Context, opts *Options)` 시그니처 변경
- 하드코딩된 `context.TODO()` 제거, 전달받은 ctx를 Extractor에 전파
- CLI 진입점에서 `cmd.Context()`로 ctx 전달 (Cobra가 제공하는 context)
- 전체 테스트 ctx 전달 업데이트

Closes #178

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)