### PR TITLE
feat: Scanner.Scan() 인터페이스에 context.Context 지원 추가

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -128,7 +128,7 @@ func (p *Packager) Package(ctx context.Context, opts *Options) (*Result, error) 
 	}
 
 	// 1. Scan files
-	scanResult, err := p.scanner.Scan()
+	scanResult, err := p.scanner.Scan(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -19,7 +19,7 @@ type mockScanner struct {
 	err    error
 }
 
-func (m *mockScanner) Scan() (*scanner.ScanResult, error) {
+func (m *mockScanner) Scan(_ context.Context) (*scanner.ScanResult, error) {
 	return m.result, m.err
 }
 

--- a/pkg/extractor/extractor_test.go
+++ b/pkg/extractor/extractor_test.go
@@ -55,7 +55,7 @@ type Point struct {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scanResult, err := sc.Scan()
+	scanResult, err := sc.Scan(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -2,6 +2,7 @@
 package scanner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -101,7 +102,8 @@ func getBaseName(path string) string {
 // Scanner defines the interface for file system scanning.
 type Scanner interface {
 	// Scan performs the scan and returns scan results.
-	Scan() (*ScanResult, error)
+	// The context allows cancellation of long-running scans.
+	Scan(ctx context.Context) (*ScanResult, error)
 }
 
 // FileScanner implements Scanner for file system traversal.
@@ -144,7 +146,7 @@ func NewFileScanner(opts *ScanOptions) (*FileScanner, error) {
 
 // Scan implements the Scanner interface.
 // It recursively traverses the directory tree and returns matching files.
-func (s *FileScanner) Scan() (*ScanResult, error) {
+func (s *FileScanner) Scan(ctx context.Context) (*ScanResult, error) {
 	result := &ScanResult{}
 
 	// Warn once if gitignore loading failed
@@ -172,6 +174,11 @@ func (s *FileScanner) Scan() (*ScanResult, error) {
 
 	// Directory - walk recursively using WalkDir (more efficient than Walk)
 	err = filepath.WalkDir(s.opts.RootPath, func(path string, d fs.DirEntry, err error) error {
+		// Check context cancellation
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+
 		if err != nil {
 			var warning string
 			switch {

--- a/pkg/scanner/scanner_bench_test.go
+++ b/pkg/scanner/scanner_bench_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,7 +53,7 @@ func Func` + string(rune('A'+i%26)) + `() int {
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				_, err := s.Scan()
+				_, err := s.Scan(context.Background())
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -101,7 +102,7 @@ func Func`+string(rune('A'+i%26))+string(rune('a'+(i/26)%26))+`() int {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, err := s.Scan()
+		_, err := s.Scan(context.Background())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -155,7 +156,7 @@ node_modules/
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, err := s.Scan()
+		_, err := s.Scan(context.Background())
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -154,7 +155,7 @@ func TestScanEmptyDirectory(t *testing.T) {
 	opts.RootPath = tmpDir
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestScanSingleFile(t *testing.T) {
 	opts.RootPath = tmpDir
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -228,7 +229,7 @@ func TestScanFilterByExtension(t *testing.T) {
 	opts.RootPath = tmpDir
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestScanExcludeHidden(t *testing.T) {
 	opts.IncludeHidden = false
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -312,7 +313,7 @@ func TestScanIncludeHidden(t *testing.T) {
 	opts.IncludeHidden = true
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -350,7 +351,7 @@ func TestScanMaxFileSize(t *testing.T) {
 	opts.MaxFileSize = 512000 // 500KB
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -404,7 +405,7 @@ func TestScanGitignore(t *testing.T) {
 	opts.IgnoreFile = gitignore
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -443,7 +444,7 @@ func TestScanGitignoreLoadFailureWarning(t *testing.T) {
 		var buf bytes.Buffer
 		sc.logger = log.New(&buf, "[brfit] ", 0)
 
-		_, err = sc.Scan()
+		_, err = sc.Scan(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -466,7 +467,7 @@ func TestScanGitignoreLoadFailureWarning(t *testing.T) {
 		var buf bytes.Buffer
 		sc.logger = log.New(&buf, "[brfit] ", 0)
 
-		_, err = sc.Scan()
+		_, err = sc.Scan(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -489,8 +490,8 @@ func TestScanGitignoreLoadFailureWarning(t *testing.T) {
 		var buf bytes.Buffer
 		sc.logger = log.New(&buf, "[brfit] ", 0)
 
-		_, _ = sc.Scan()
-		_, _ = sc.Scan()
+		_, _ = sc.Scan(context.Background())
+		_, _ = sc.Scan(context.Background())
 
 		warnCount := strings.Count(buf.String(), "WARN")
 		if warnCount != 1 {
@@ -539,7 +540,7 @@ func TestScanWalkDirPermissionDenied(t *testing.T) {
 	var buf bytes.Buffer
 	sc.logger = log.New(&buf, "[brfit] ", 0)
 
-	result, err := sc.Scan()
+	result, err := sc.Scan(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,7 +589,7 @@ func TestScanSymlinkSkip(t *testing.T) {
 	var buf bytes.Buffer
 	sc.logger = log.New(&buf, "[brfit] ", 0)
 
-	result, err := sc.Scan()
+	result, err := sc.Scan(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -656,7 +657,7 @@ func TestScanNestedDirectories(t *testing.T) {
 	opts.RootPath = tmpDir
 
 	scanner, _ := NewFileScanner(opts)
-	result, err := scanner.Scan()
+	result, err := scanner.Scan(context.Background())
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
@@ -698,7 +699,7 @@ func TestLogOutputNoDoubleNewline(t *testing.T) {
 	var buf bytes.Buffer
 	sc.logger = log.New(&buf, "", 0)
 
-	_, err = sc.Scan()
+	_, err = sc.Scan(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- `Scanner` 인터페이스 `Scan()` → `Scan(ctx context.Context)` 시그니처 변경
- `FileScanner.Scan`의 WalkDir 콜백에서 `ctx.Err()` 체크로 취소 시 즉시 반환
- Packager에서 받은 ctx를 Scanner로 전파 (엔드투엔드 취소 지원)
- Extractor와의 인터페이스 일관성 확보

Closes #188

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)