### PR TITLE
feat: JSON 출력에 line/exported 필드 추가

### DIFF
--- a/pkg/formatter/json.go
+++ b/pkg/formatter/json.go
@@ -43,9 +43,11 @@ type jsonFile struct {
 
 // jsonSig represents a signature in the JSON output.
 type jsonSig struct {
-	Kind string `json:"kind"`
-	Text string `json:"text"`
-	Doc  string `json:"doc,omitempty"`
+	Kind     string `json:"kind"`
+	Text     string `json:"text"`
+	Doc      string `json:"doc,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Exported bool   `json:"exported,omitempty"`
 }
 
 // Format implements Formatter interface.
@@ -82,8 +84,10 @@ func (f *JSONFormatter) Format(data *PackageData) ([]byte, error) {
 				jf.Signatures = make([]jsonSig, 0, len(file.Signatures))
 				for _, sig := range file.Signatures {
 					js := jsonSig{
-						Kind: normalizeKind(sig.Kind),
-						Text: sig.Text,
+						Kind:     normalizeKind(sig.Kind),
+						Text:     sig.Text,
+						Line:     sig.Line,
+						Exported: sig.Exported,
 					}
 					if sig.Doc != "" {
 						js.Doc = truncateDoc(sig.Doc, data.MaxDocLength)


### PR DESCRIPTION
## Summary
- `jsonSig` 구조체에 `Line int` 및 `Exported bool` 필드 추가
- `omitempty` 태그로 하위 호환성 유지 (기존 출력에 영향 없음)
- `parser.Signature`에 이미 존재하는 필드를 JSON 출력에 노출

Closes #184

## Test plan
- [x] 전체 테스트 통과 (`go test ./...`)
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)