### PR TITLE
docs: brfit-mcp MCP 서버 문서 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `brfit-mcp` MCP (Model Context Protocol) 서버 바이너리 — AI 에이전트용 stdio JSON-RPC 서버, `summarize_project`/`summarize_file` 도구 제공 (#192)
 - 함수 호출 참조 그래프 출력 (`--call-graph`) — Tree-sitter 기반 함수 호출 관계 추출 (Go, TypeScript, Python, Java, Rust, C) (#191)
 - 보안 민감 정보 감지 및 마스킹 (`--security-check`) — 기본 활성화, AWS/GitHub/API 키 등 12종 패턴 감지 후 `[REDACTED]` 마스킹 (#190)
 - `--token-tree` flag to display per-file token counts in tree format (#187)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,36 @@
 
 ---
 
+## MCP 서버 (`brfit-mcp`)
+
+`brfit-mcp`는 brfit의 코드 분석 기능을 AI 에이전트에 노출하는 독립 실행형 MCP (Model Context Protocol) 서버 바이너리입니다.
+
+- **통신**: stdio (JSON-RPC)
+- **실행**: `brfit-mcp --root /path/to/project`
+- **진입점**: `cmd/brfit-mcp/main.go`
+
+### 제공 도구
+
+| 도구 | 설명 |
+|------|------|
+| `summarize_project` | 프로젝트 디렉토리에서 시그니처 추출. 옵션: `path`, `format`, `include_body`, `include_imports`, `call_graph` |
+| `summarize_file` | glob 패턴 매칭 파일에서 시그니처 추출. 옵션: `path`, `include`, `format` |
+
+### Claude Desktop 연동 설정
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```
+
+---
+
 ## Go Engineering Conventions
 
 Claude, brf.it 프로젝트를 **Go(Golang)**로 구현할 때 준수해야 할 엄격한 컨벤션입니다. Go의 특성을 살려 빠르고, 작고, 견고한 CLI 도구를 만드는 데 집중하세요.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,40 @@ brfit . --include-imports
 
 <br/>
 
+## MCP Server
+
+`brfit-mcp` is a standalone [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes brfit's code analysis as tools for AI agents. It communicates over stdio (JSON-RPC).
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `summarize_project` | Extract signatures from a project directory. Options: `path`, `format`, `include_body`, `include_imports`, `call_graph` |
+| `summarize_file` | Extract signatures from files matching a glob pattern. Options: `path`, `include`, `format` |
+
+### Usage
+
+```bash
+brfit-mcp --root /path/to/project
+```
+
+### Claude Desktop Configuration
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```
+
+---
+
+<br/>
+
 ## License
 
 MIT License — Use freely in personal and commercial projects.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -239,3 +239,54 @@ brfit . -o context.xml
 # Use in scripts
 brfit . --no-tokens --no-tree > signatures.xml
 ```
+
+---
+
+## MCP Server (`brfit-mcp`)
+
+`brfit-mcp` is a standalone [Model Context Protocol](https://modelcontextprotocol.io/) server binary that exposes brfit's code analysis as tools for AI agents. It communicates over stdio using JSON-RPC.
+
+### Usage
+
+```bash
+brfit-mcp --root /path/to/project
+```
+
+### Tools
+
+#### `summarize_project`
+
+Extract signatures from a project directory.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `path` | Project directory path | Server `--root` value |
+| `format` | Output format (`xml`, `md`) | `xml` |
+| `include_body` | Include function bodies | `false` |
+| `include_imports` | Include import statements | `false` |
+| `call_graph` | Extract function call relationships | `false` |
+
+#### `summarize_file`
+
+Extract signatures from files matching a glob pattern.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `path` | Base directory path | Server `--root` value |
+| `include` | Glob pattern(s) to match files | |
+| `format` | Output format (`xml`, `md`) | `xml` |
+
+### Claude Desktop Configuration
+
+Add to your Claude Desktop `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -220,6 +220,40 @@ brfit . --include-imports
 
 <br/>
 
+## MCP-Server
+
+`brfit-mcp` ist ein eigenstandiger [Model Context Protocol](https://modelcontextprotocol.io/)-Server, der brfits Code-Analyse als Werkzeuge fur KI-Agenten bereitstellt. Er kommuniziert uber stdio (JSON-RPC).
+
+### Werkzeuge
+
+| Werkzeug | Beschreibung |
+|----------|--------------|
+| `summarize_project` | Signaturen aus einem Projektverzeichnis extrahieren. Optionen: `path`, `format`, `include_body`, `include_imports`, `call_graph` |
+| `summarize_file` | Signaturen aus Dateien extrahieren, die einem Glob-Muster entsprechen. Optionen: `path`, `include`, `format` |
+
+### Verwendung
+
+```bash
+brfit-mcp --root /path/to/project
+```
+
+### Claude Desktop-Konfiguration
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```
+
+---
+
+<br/>
+
 ## Lizenz
 
 MIT-Lizenz — Frei verwendbar in persönlichen und kommerziellen Projekten.

--- a/docs/hi/README.md
+++ b/docs/hi/README.md
@@ -220,6 +220,40 @@ brfit . --include-imports
 
 <br/>
 
+## MCP सर्वर
+
+`brfit-mcp` एक स्टैंडअलोन [Model Context Protocol](https://modelcontextprotocol.io/) सर्वर है जो brfit के कोड विश्लेषण को AI एजेंटों के लिए टूल्स के रूप में प्रदान करता है। यह stdio (JSON-RPC) पर संवाद करता है।
+
+### टूल्स
+
+| टूल | विवरण |
+|------|-------|
+| `summarize_project` | प्रोजेक्ट डायरेक्टरी से सिग्नेचर निकालें। विकल्प: `path`, `format`, `include_body`, `include_imports`, `call_graph` |
+| `summarize_file` | glob पैटर्न से मेल खाने वाली फाइलों से सिग्नेचर निकालें। विकल्प: `path`, `include`, `format` |
+
+### उपयोग
+
+```bash
+brfit-mcp --root /path/to/project
+```
+
+### Claude Desktop कॉन्फ़िगरेशन
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```
+
+---
+
+<br/>
+
 ## लाइसेंस
 
 MIT लाइसेंस — व्यक्तिगत और व्यावसायिक प्रोजेक्ट में स्वतंत्र रूप से उपयोग करें।

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -220,6 +220,40 @@ brfit . --include-imports
 
 <br/>
 
+## MCPサーバー
+
+`brfit-mcp`は、brfitのコード分析をAIエージェント向けツールとして提供するスタンドアロンの[Model Context Protocol](https://modelcontextprotocol.io/)サーバーです。stdio（JSON-RPC）で通信します。
+
+### ツール
+
+| ツール | 説明 |
+|--------|------|
+| `summarize_project` | プロジェクトディレクトリからシグネチャを抽出。オプション: `path`, `format`, `include_body`, `include_imports`, `call_graph` |
+| `summarize_file` | globパターンに一致するファイルからシグネチャを抽出。オプション: `path`, `include`, `format` |
+
+### 使用方法
+
+```bash
+brfit-mcp --root /path/to/project
+```
+
+### Claude Desktop設定
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```
+
+---
+
+<br/>
+
 ## ライセンス
 
 MITライセンス — 個人・商用プロジェクトで自由に使用できます。

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -220,6 +220,40 @@ brfit . --include-imports
 
 <br/>
 
+## MCP 서버
+
+`brfit-mcp`는 brfit의 코드 분석을 AI 에이전트용 도구로 제공하는 독립 실행형 [Model Context Protocol](https://modelcontextprotocol.io/) 서버입니다. stdio (JSON-RPC)로 통신합니다.
+
+### 도구
+
+| 도구 | 설명 |
+|------|------|
+| `summarize_project` | 프로젝트 디렉토리에서 시그니처 추출. 옵션: `path`, `format`, `include_body`, `include_imports`, `call_graph` |
+| `summarize_file` | glob 패턴에 매칭되는 파일에서 시그니처 추출. 옵션: `path`, `include`, `format` |
+
+### 사용법
+
+```bash
+brfit-mcp --root /path/to/project
+```
+
+### Claude Desktop 설정
+
+```json
+{
+  "mcpServers": {
+    "brfit": {
+      "command": "brfit-mcp",
+      "args": ["--root", "/path/to/project"]
+    }
+  }
+}
+```
+
+---
+
+<br/>
+
 ## 라이선스
 
 MIT 라이선스 — 개인 및 상업 프로젝트에서 자유롭게 사용 가능합니다.


### PR DESCRIPTION
## Summary
- Add `brfit-mcp` MCP server documentation across all 8 project files
- CHANGELOG.md: new entry under `[Unreleased]` > `### Added`
- README.md + 4 localized READMEs (ko, ja, de, hi): new MCP Server section with tools, usage, and Claude Desktop config
- CLAUDE.md: new MCP server section with tool descriptions and integration config
- docs/cli-reference.md: full `brfit-mcp` reference with tool parameters and configuration

Closes #192

## Test plan
- [ ] Verify all 8 files render correctly on GitHub
- [ ] Confirm JSON config blocks are valid
- [ ] Check localized READMEs match English structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)