### PR TITLE
fix: git ls-files 및 filepath.Rel 실패 시 경고 출력

### DIFF
--- a/cmd/brfit/root.go
+++ b/cmd/brfit/root.go
@@ -405,7 +405,9 @@ func resolveChangedFiles(rootPath string, changed bool, since string) (map[strin
 		lsCmd := exec.Command("git", "ls-files", "--others", "--exclude-standard")
 		lsCmd.Dir = dir
 		lsOut, err := lsCmd.Output()
-		if err == nil {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[brfit] WARN: git ls-files failed (untracked files may be missing): %v\n", err)
+		} else {
 			gitRelPaths = append(gitRelPaths, splitNonEmpty(string(lsOut))...)
 		}
 	}
@@ -438,6 +440,7 @@ func resolveChangedFiles(rootPath string, changed bool, since string) (map[strin
 		// Compute path relative to rootPath
 		rel, err := filepath.Rel(absRoot, absPath)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "[brfit] WARN: failed to compute relative path for %s: %v\n", absPath, err)
 			continue
 		}
 


### PR DESCRIPTION
Closes #240
Closes #243

## Summary
- `--changed` 모드에서 `git ls-files` 실패 시 stderr 경고 출력 (untracked 파일 누락 알림)
- `resolveChangedFiles`에서 `filepath.Rel` 실패 시 stderr 경고 출력

## Test plan
- [x] `go test ./cmd/brfit/` 통과
- [x] `go build ./cmd/brfit` 성공