### PR TITLE
fix: TreeSitterParser Close() 메서드 추가로 쿼리 캐시 정리

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -97,6 +97,19 @@ func NewTreeSitterParser() *TreeSitterParser {
 	return p
 }
 
+// Close releases all cached Tree-sitter Query objects.
+// This should be called when the parser is no longer needed,
+// especially in long-running processes like brfit-mcp.
+func (p *TreeSitterParser) Close() {
+	p.compiledQueries.Range(func(key, value any) bool {
+		if q, ok := value.(*sitter.Query); ok {
+			q.Close()
+		}
+		p.compiledQueries.Delete(key)
+		return true
+	})
+}
+
 // getOrCreateQuery returns a cached query or creates and caches a new one.
 // The returned query should NOT be closed by the caller - it's managed by the cache.
 func (p *TreeSitterParser) getOrCreateQuery(lang string, langQuery LanguageQuery, typ queryType) (*sitter.Query, error) {


### PR DESCRIPTION
Closes #241

## Summary
- `TreeSitterParser`에 `Close()` 메서드 추가
- `compiledQueries` sync.Map의 모든 캐시된 Query 객체를 명시적으로 Close

## Test plan
- [x] `go test ./pkg/parser/treesitter/` 통과
- [x] `go test ./...` 전체 통과