### PR TITLE
perf: truncateDoc rune 변환 최적화

### DIFF
--- a/pkg/formatter/helpers.go
+++ b/pkg/formatter/helpers.go
@@ -1,5 +1,7 @@
 package formatter
 
+import "unicode/utf8"
+
 // normalizeKind normalizes a signature kind string to one of the canonical
 // categories: "function", "type", or "variable". If the kind does not match
 // any known category, it is returned unchanged.
@@ -38,10 +40,10 @@ func truncateDoc(doc string, maxLen int) string {
 		return doc
 	}
 
-	runes := []rune(doc)
-	if len(runes) <= maxLen {
+	if utf8.RuneCountInString(doc) <= maxLen {
 		return doc
 	}
 
+	runes := []rune(doc)
 	return string(runes[:maxLen]) + "..."
 }


### PR DESCRIPTION
Closes #242

## Summary
- `truncateDoc()`에서 `utf8.RuneCountInString()`으로 문자열 길이를 먼저 확인하여 truncation이 불필요한 경우 `[]rune` 할당을 방지

## Test plan
- [x] `go test ./pkg/formatter/` 통과
- [x] 기존 동작 변경 없음 (truncation이 필요한 경우에만 rune 슬라이스 생성)