### PR TITLE
perf: Scanner relPath() 내 os.Stat 결과 캐싱

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -129,6 +129,7 @@ type FileScanner struct {
 	ignorerErrs       []error
 	ignorerErrsWarned bool
 	logger            *log.Logger
+	rootIsFile        bool
 }
 
 // NewFileScanner creates a new FileScanner with the given options.
@@ -150,9 +151,17 @@ func NewFileScanner(opts *ScanOptions) (*FileScanner, error) {
 		}
 	}
 
+	// Cache whether RootPath is a file (not a directory) to avoid
+	// repeated os.Stat calls in relPath().
+	var rootIsFile bool
+	if info, err := os.Stat(opts.RootPath); err == nil && !info.IsDir() {
+		rootIsFile = true
+	}
+
 	s := &FileScanner{
-		opts:   opts,
-		logger: log.New(os.Stderr, "[brfit] ", 0),
+		opts:       opts,
+		logger:     log.New(os.Stderr, "[brfit] ", 0),
+		rootIsFile: rootIsFile,
 	}
 
 	// Try to load each ignore file
@@ -293,7 +302,7 @@ func (s *FileScanner) relPath(path string) string {
 	base := s.opts.RootPath
 	// If RootPath is a file, use its parent as the base for relative paths.
 	// This ensures glob matching works (e.g., "**/*.go" matches "main.go").
-	if info, err := os.Stat(base); err == nil && !info.IsDir() {
+	if s.rootIsFile {
 		base = filepath.Dir(base)
 	}
 	rel, err := filepath.Rel(base, path)


### PR DESCRIPTION
Closes #237

## Summary
- `NewFileScanner()` 초기화 시 `os.Stat(RootPath)` 결과를 `rootIsFile` 필드로 캐싱
- `relPath()` 호출마다 반복되던 `os.Stat()` syscall 제거

## Test plan
- [x] `go test ./pkg/scanner/` 통과
- [x] 기존 동작 변경 없음 (단일 파일 스캔, 디렉토리 스캔 모두 정상)