### PR TITLE
docs: README에 Downloads 및 Languages 통계 뱃지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 🌐 [English](README.md) | [한국어](docs/ko/README.md) | [日本語](docs/ja/README.md) | [हिन्दी](docs/hi/README.md) | [Deutsch](docs/de/README.md)
 
 [![Release](https://img.shields.io/github/v/release/indigo-net/Brf.it)](https://github.com/indigo-net/Brf.it/releases)
+[![Downloads](https://img.shields.io/github/downloads/indigo-net/Brf.it/total)](https://github.com/indigo-net/Brf.it/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/indigo-net/Brf.it)](https://goreportcard.com/report/github.com/indigo-net/Brf.it)
 [![Coverage](https://codecov.io/gh/indigo-net/Brf.it/branch/main/graph/badge.svg)](https://codecov.io/gh/indigo-net/Brf.it)
+[![Languages](https://img.shields.io/badge/languages-19-blue)](https://indigo-net.github.io/Brf.it/docs/languages/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **Package your codebase for AI comprehension.**

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -7,7 +7,9 @@
 🌐 [English](../../README.md) | [한국어](../ko/README.md) | [日本語](../ja/README.md) | [हिन्दी](../hi/README.md) | [Deutsch](README.md)
 
 [![Release](https://img.shields.io/github/v/release/indigo-net/Brf.it)](https://github.com/indigo-net/Brf.it/releases)
+[![Downloads](https://img.shields.io/github/downloads/indigo-net/Brf.it/total)](https://github.com/indigo-net/Brf.it/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/indigo-net/Brf.it)](https://goreportcard.com/report/github.com/indigo-net/Brf.it)
+[![Languages](https://img.shields.io/badge/languages-19-blue)](https://indigo-net.github.io/Brf.it/docs/languages/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **Verpacken Sie Ihre Codebasis für KI-Verständnis.**

--- a/docs/hi/README.md
+++ b/docs/hi/README.md
@@ -7,7 +7,9 @@
 🌐 [English](../../README.md) | [한국어](../ko/README.md) | [日本語](../ja/README.md) | [हिन्दी](README.md) | [Deutsch](../de/README.md)
 
 [![Release](https://img.shields.io/github/v/release/indigo-net/Brf.it)](https://github.com/indigo-net/Brf.it/releases)
+[![Downloads](https://img.shields.io/github/downloads/indigo-net/Brf.it/total)](https://github.com/indigo-net/Brf.it/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/indigo-net/Brf.it)](https://goreportcard.com/report/github.com/indigo-net/Brf.it)
+[![Languages](https://img.shields.io/badge/languages-19-blue)](https://indigo-net.github.io/Brf.it/docs/languages/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **अपने कोडबेस को AI समझ के लिए पैकेज करें।**

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -7,7 +7,9 @@
 🌐 [English](../../README.md) | [한국어](../ko/README.md) | [日本語](README.md) | [हिन्दी](../hi/README.md) | [Deutsch](../de/README.md)
 
 [![Release](https://img.shields.io/github/v/release/indigo-net/Brf.it)](https://github.com/indigo-net/Brf.it/releases)
+[![Downloads](https://img.shields.io/github/downloads/indigo-net/Brf.it/total)](https://github.com/indigo-net/Brf.it/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/indigo-net/Brf.it)](https://goreportcard.com/report/github.com/indigo-net/Brf.it)
+[![Languages](https://img.shields.io/badge/languages-19-blue)](https://indigo-net.github.io/Brf.it/docs/languages/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **コードベースをAIが理解しやすい形式にパッケージング**

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -7,7 +7,9 @@
 🌐 [English](../../README.md) | [한국어](README.md) | [日本語](../ja/README.md) | [हिन्दी](../hi/README.md) | [Deutsch](../de/README.md)
 
 [![Release](https://img.shields.io/github/v/release/indigo-net/Brf.it)](https://github.com/indigo-net/Brf.it/releases)
+[![Downloads](https://img.shields.io/github/downloads/indigo-net/Brf.it/total)](https://github.com/indigo-net/Brf.it/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/indigo-net/Brf.it)](https://goreportcard.com/report/github.com/indigo-net/Brf.it)
+[![Languages](https://img.shields.io/badge/languages-19-blue)](https://indigo-net.github.io/Brf.it/docs/languages/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **코드베이스를 AI가 이해하기 쉬운 형태로 패키징**


### PR DESCRIPTION
Closes #17 (부분 해결: 뱃지 추가)

## Summary
- GitHub Downloads 총 다운로드 수 뱃지 (shields.io)
- 지원 언어 19개 뱃지
- 5개 README (EN, KO, JA, HI, DE) 동기화

## Test plan
- [ ] shields.io 뱃지 렌더링 확인
- [ ] 링크 유효성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)