### PR TITLE
fix: MCP resolvePath 절대 경로 입력 차단 및 경로 탈출 방어 강화

### DIFF
--- a/cmd/brfit-mcp/main.go
+++ b/cmd/brfit-mcp/main.go
@@ -188,20 +188,27 @@ var validFormats = map[string]bool{"xml": true, "md": true, "markdown": true, "j
 // resolvePath resolves an input path relative to the default root, ensuring
 // the result stays within the root directory to prevent path traversal.
 // If inputPath is empty, defaultRoot is returned unchanged.
+// Absolute paths are rejected outright; relative paths are joined with
+// defaultRoot and then verified to remain within the root boundary.
 func resolvePath(defaultRoot, inputPath string) (string, error) {
 	if inputPath == "" {
 		return defaultRoot, nil
 	}
 
-	absPath, err := filepath.Abs(inputPath)
-	if err != nil {
-		return "", fmt.Errorf("invalid path: %w", err)
+	// Reject absolute paths to prevent escaping the project root.
+	if filepath.IsAbs(inputPath) {
+		return "", fmt.Errorf("absolute path %q is not allowed; use a relative path within the project root %q", inputPath, defaultRoot)
 	}
 
-	// Ensure the resolved path is within the project root.
-	rel, err := filepath.Rel(defaultRoot, absPath)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("path %q is outside the project root %q", inputPath, defaultRoot)
+	// Join with defaultRoot (not CWD) and clean the result.
+	joined := filepath.Join(defaultRoot, inputPath)
+	absPath := filepath.Clean(joined)
+
+	// Verify the cleaned path is still within the project root.
+	// Use Clean on defaultRoot too for consistent comparison.
+	cleanRoot := filepath.Clean(defaultRoot)
+	if absPath != cleanRoot && !strings.HasPrefix(absPath, cleanRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q resolves outside the project root %q", inputPath, defaultRoot)
 	}
 
 	return absPath, nil

--- a/cmd/brfit-mcp/main_test.go
+++ b/cmd/brfit-mcp/main_test.go
@@ -83,12 +83,13 @@ func TestPathTraversal(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	tests := []struct {
-		name string
-		path string
+		name    string
+		path    string
+		errPart string
 	}{
-		{"relative traversal", "../../etc"},
-		{"absolute escape", "/etc"},
-		{"dot-dot in middle", "subdir/../../etc"},
+		{"relative traversal", "../../etc", "resolves outside the project root"},
+		{"absolute escape", "/etc", "absolute path"},
+		{"dot-dot in middle", "subdir/../../etc", "resolves outside the project root"},
 	}
 
 	for _, tt := range tests {
@@ -100,8 +101,8 @@ func TestPathTraversal(t *testing.T) {
 			if err == nil {
 				t.Error("expected error for path traversal attempt")
 			}
-			if err != nil && !strings.Contains(err.Error(), "outside the project root") {
-				t.Errorf("expected 'outside the project root' error, got: %v", err)
+			if err != nil && !strings.Contains(err.Error(), tt.errPart) {
+				t.Errorf("expected %q error, got: %v", tt.errPart, err)
 			}
 		})
 
@@ -113,8 +114,8 @@ func TestPathTraversal(t *testing.T) {
 			if err == nil {
 				t.Error("expected error for path traversal attempt")
 			}
-			if err != nil && !strings.Contains(err.Error(), "outside the project root") {
-				t.Errorf("expected 'outside the project root' error, got: %v", err)
+			if err != nil && !strings.Contains(err.Error(), tt.errPart) {
+				t.Errorf("expected %q error, got: %v", tt.errPart, err)
 			}
 		})
 	}
@@ -151,13 +152,57 @@ func TestValidSubdirectoryPath(t *testing.T) {
 	}
 
 	handler := makeSummarizeProject(tmpDir)
+	// Use relative path (absolute paths are now rejected)
 	_, output, err := handler(context.Background(), &mcp.CallToolRequest{}, SummarizeProjectInput{
-		Path: subDir,
+		Path: "sub",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error for valid subdirectory: %v", err)
 	}
 	if output.TotalFiles == 0 {
 		t.Error("expected at least 1 file")
+	}
+}
+
+func TestResolvePathAbsoluteRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Absolute paths should be rejected even if they point within the root
+	absInRoot := filepath.Join(tmpDir, "sub")
+	_, err := resolvePath(tmpDir, absInRoot)
+	if err == nil {
+		t.Error("expected error for absolute path input")
+	}
+	if err != nil && !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("expected 'absolute path' error, got: %v", err)
+	}
+}
+
+func TestResolvePathValidRelative(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "sub")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := resolvePath(tmpDir, "sub")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Clean(filepath.Join(tmpDir, "sub"))
+	if resolved != expected {
+		t.Errorf("expected %q, got %q", expected, resolved)
+	}
+}
+
+func TestResolvePathEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	resolved, err := resolvePath(tmpDir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != tmpDir {
+		t.Errorf("expected %q, got %q", tmpDir, resolved)
 	}
 }


### PR DESCRIPTION
## Summary
- MCP `resolvePath()`에서 절대 경로 입력을 즉시 거부하여 경로 탈출 공격 차단
- 상대 경로를 CWD가 아닌 `defaultRoot` 기준으로 해석하도록 수정
- `filepath.Clean` + prefix 비교로 이중 검증

## Changes
- `resolvePath()`: 절대 경로 거부 → 상대 경로만 `filepath.Join(defaultRoot, inputPath)` → Clean + prefix 검증
- 테스트 3개 추가: `TestResolvePathAbsoluteRejected`, `TestResolvePathValidRelative`, `TestResolvePathEmpty`
- 기존 `TestPathTraversal` 에러 메시지 검증 세분화

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)