### PR TITLE
fix: isExported() 언어별 가시성 규칙 구현

### DIFF
--- a/pkg/parser/treesitter/languages/base.go
+++ b/pkg/parser/treesitter/languages/base.go
@@ -1,5 +1,18 @@
 package languages
 
+import "strings"
+
+// hasVisibilityPrefix checks if the first line of sigText starts with the given modifier.
+// This avoids false positives from matching modifiers inside function bodies.
+func hasVisibilityPrefix(sigText, modifier string) bool {
+	first := sigText
+	if idx := strings.IndexByte(sigText, '\n'); idx >= 0 {
+		first = sigText[:idx]
+	}
+	return strings.HasPrefix(strings.TrimSpace(first), modifier+" ") ||
+		strings.Contains(first, " "+modifier+" ")
+}
+
 // BaseQuery provides default implementations for common LanguageQuery methods.
 // Embed this struct to get the default Captures() implementation.
 type BaseQuery struct{}
@@ -22,4 +35,10 @@ func (BaseQuery) ImportQuery() []byte {
 // CallQuery returns nil by default (no call extraction support).
 func (BaseQuery) CallQuery() []byte {
 	return nil
+}
+
+// IsExported returns true for any non-empty name by default.
+// Languages with explicit visibility rules should override this method.
+func (BaseQuery) IsExported(name, _ string) bool {
+	return len(name) > 0
 }

--- a/pkg/parser/treesitter/languages/c.go
+++ b/pkg/parser/treesitter/languages/c.go
@@ -2,6 +2,8 @@
 package languages
 
 import (
+	"strings"
+
 	sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_c "github.com/tree-sitter/tree-sitter-c/bindings/go"
 )
@@ -55,6 +57,14 @@ func (q *CQuery) ImportQuery() []byte {
 // CallQuery returns the C call query pattern.
 func (q *CQuery) CallQuery() []byte {
 	return []byte(cCallQueryPattern)
+}
+
+// IsExported returns true if the C signature is not file-local (static).
+func (q *CQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !strings.HasPrefix(sigText, "static ")
 }
 
 // cCallQueryPattern is the Tree-sitter query for extracting C function calls.

--- a/pkg/parser/treesitter/languages/cpp.go
+++ b/pkg/parser/treesitter/languages/cpp.go
@@ -2,6 +2,8 @@
 package languages
 
 import (
+	"strings"
+
 	sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_cpp "github.com/tree-sitter/tree-sitter-cpp/bindings/go"
 )
@@ -53,6 +55,14 @@ func (q *CppQuery) KindMapping() map[string]string {
 // ImportQuery returns the C++ import query pattern.
 func (q *CppQuery) ImportQuery() []byte {
 	return []byte(cppImportQueryPattern)
+}
+
+// IsExported returns true if the C++ signature is not file-local (static).
+func (q *CppQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !strings.HasPrefix(sigText, "static ")
 }
 
 // cppImportQueryPattern is the Tree-sitter query for extracting C++ #include directives.

--- a/pkg/parser/treesitter/languages/csharp.go
+++ b/pkg/parser/treesitter/languages/csharp.go
@@ -63,6 +63,14 @@ func (q *CSharpQuery) ImportQuery() []byte {
 	return []byte(csharpImportQueryPattern)
 }
 
+// IsExported returns true if the C# signature does not start with a private modifier.
+func (q *CSharpQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !hasVisibilityPrefix(sigText, "private") && !hasVisibilityPrefix(sigText, "internal")
+}
+
 // csharpImportQueryPattern is the Tree-sitter query for extracting C# using directives.
 const csharpImportQueryPattern = `
 ; using directives (capture full declaration)

--- a/pkg/parser/treesitter/languages/elixir.go
+++ b/pkg/parser/treesitter/languages/elixir.go
@@ -2,6 +2,8 @@
 package languages
 
 import (
+	"strings"
+
 	tree_sitter_elixir "github.com/indigo-net/Brf.it/pkg/parser/treesitter/grammars/elixir"
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
@@ -46,6 +48,14 @@ func (q *ElixirQuery) KindMapping() map[string]string {
 // ImportQuery returns the Elixir import query pattern.
 func (q *ElixirQuery) ImportQuery() []byte {
 	return []byte(elixirImportQueryPattern)
+}
+
+// IsExported returns true if the Elixir definition uses def (not defp).
+func (q *ElixirQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !strings.HasPrefix(sigText, "defp ")
 }
 
 // elixirImportQueryPattern is the Tree-sitter query for extracting Elixir

--- a/pkg/parser/treesitter/languages/go.go
+++ b/pkg/parser/treesitter/languages/go.go
@@ -64,6 +64,14 @@ func (q *GoQuery) CallQuery() []byte {
 	return []byte(goCallQueryPattern)
 }
 
+// IsExported returns true if the Go identifier starts with an uppercase letter.
+func (q *GoQuery) IsExported(name, _ string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return name[0] >= 'A' && name[0] <= 'Z'
+}
+
 // goCallQueryPattern is the Tree-sitter query for extracting Go function calls.
 const goCallQueryPattern = `
 ; Direct function calls (e.g., foo())

--- a/pkg/parser/treesitter/languages/java.go
+++ b/pkg/parser/treesitter/languages/java.go
@@ -57,6 +57,14 @@ func (q *JavaQuery) CallQuery() []byte {
 	return []byte(javaCallQueryPattern)
 }
 
+// IsExported returns true if the Java signature does not start with a private modifier.
+func (q *JavaQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !hasVisibilityPrefix(sigText, "private")
+}
+
 // javaCallQueryPattern is the Tree-sitter query for extracting Java method invocations.
 const javaCallQueryPattern = `
 ; Method invocations (e.g., obj.method(), method())

--- a/pkg/parser/treesitter/languages/kotlin.go
+++ b/pkg/parser/treesitter/languages/kotlin.go
@@ -52,6 +52,14 @@ func (q *KotlinQuery) ImportQuery() []byte {
 	return []byte(kotlinImportQueryPattern)
 }
 
+// IsExported returns true if the Kotlin signature does not start with a private modifier.
+func (q *KotlinQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !hasVisibilityPrefix(sigText, "private") && !hasVisibilityPrefix(sigText, "internal")
+}
+
 // kotlinImportQueryPattern is the Tree-sitter query for extracting Kotlin import statements.
 const kotlinImportQueryPattern = `
 ; Import statements

--- a/pkg/parser/treesitter/languages/php.go
+++ b/pkg/parser/treesitter/languages/php.go
@@ -53,6 +53,14 @@ func (q *PHPQuery) ImportQuery() []byte {
 	return []byte(phpImportQueryPattern)
 }
 
+// IsExported returns true if the PHP signature does not start with a private modifier.
+func (q *PHPQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !hasVisibilityPrefix(sigText, "private")
+}
+
 // phpImportQueryPattern is the Tree-sitter query for extracting PHP use/include statements.
 const phpImportQueryPattern = `
 ; use Namespace\\Class;

--- a/pkg/parser/treesitter/languages/python.go
+++ b/pkg/parser/treesitter/languages/python.go
@@ -52,6 +52,15 @@ func (q *PythonQuery) CallQuery() []byte {
 	return []byte(pythonCallQueryPattern)
 }
 
+// IsExported returns true if the Python name does not start with underscore.
+// Single underscore prefix (_name) is a convention for internal/private symbols.
+func (q *PythonQuery) IsExported(name, _ string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return name[0] != '_'
+}
+
 // pythonCallQueryPattern is the Tree-sitter query for extracting Python function calls.
 const pythonCallQueryPattern = `
 ; Direct function calls (e.g., foo())

--- a/pkg/parser/treesitter/languages/rust.go
+++ b/pkg/parser/treesitter/languages/rust.go
@@ -63,6 +63,14 @@ func (q *RustQuery) CallQuery() []byte {
 	return []byte(rustCallQueryPattern)
 }
 
+// IsExported returns true for Rust items. In Rust, items without `pub` are
+// still crate-visible, which is exported enough for project-level analysis.
+// Only items explicitly marked with restricted visibility (e.g., inside impl
+// blocks) would be truly private, but that requires AST context beyond sigText.
+func (q *RustQuery) IsExported(name, _ string) bool {
+	return len(name) > 0
+}
+
 // rustCallQueryPattern is the Tree-sitter query for extracting Rust function calls.
 const rustCallQueryPattern = `
 ; Direct function calls (e.g., foo())

--- a/pkg/parser/treesitter/languages/scala.go
+++ b/pkg/parser/treesitter/languages/scala.go
@@ -56,6 +56,14 @@ func (q *ScalaQuery) ImportQuery() []byte {
 	return []byte(scalaImportQueryPattern)
 }
 
+// IsExported returns true if the Scala signature does not start with a private modifier.
+func (q *ScalaQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !hasVisibilityPrefix(sigText, "private")
+}
+
 // scalaImportQueryPattern is the Tree-sitter query for extracting Scala import statements.
 const scalaImportQueryPattern = `
 ; Import statements

--- a/pkg/parser/treesitter/languages/swift.go
+++ b/pkg/parser/treesitter/languages/swift.go
@@ -54,6 +54,14 @@ func (q *SwiftQuery) ImportQuery() []byte {
 	return []byte(swiftImportQueryPattern)
 }
 
+// IsExported returns true if the Swift signature does not start with a private modifier.
+func (q *SwiftQuery) IsExported(name, sigText string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return !hasVisibilityPrefix(sigText, "private") && !hasVisibilityPrefix(sigText, "fileprivate")
+}
+
 // swiftImportQueryPattern is the Tree-sitter query for extracting Swift import statements.
 const swiftImportQueryPattern = `
 ; Import declarations (capture full statement)

--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -204,13 +204,24 @@ func (p *TreeSitterParser) Parse(content []byte, opts *parser.Options) (result *
 		}
 	}
 
-	// Extract calls if requested
+	// Extract calls if requested (uses full signatures for caller attribution)
 	var calls []parser.FunctionCall
 	if opts.IncludeCalls && query.CallQuery() != nil {
 		calls, err = p.extractCalls(tree.RootNode(), content, query, opts, signatures)
 		if err != nil {
 			return nil, fmt.Errorf("call extraction failed: %w", err)
 		}
+	}
+
+	// Filter private symbols after call extraction (calls need all signatures for caller attribution)
+	if !opts.IncludePrivate {
+		filtered := signatures[:0]
+		for _, sig := range signatures {
+			if sig.Exported {
+				filtered = append(filtered, sig)
+			}
+		}
+		signatures = filtered
 	}
 
 	return &parser.ParseResult{
@@ -448,10 +459,7 @@ func (p *TreeSitterParser) extractSignatures(
 			}
 			seen[dk] = true
 
-			// Filter private if needed
-			if !opts.IncludePrivate && !isExported(sig.Name, opts.Language) {
-				continue
-			}
+			sig.Exported = langQuery.IsExported(sig.Name, sig.Text)
 
 			// Strip body if IncludeBody is false (default)
 			if !opts.IncludeBody {
@@ -459,7 +467,6 @@ func (p *TreeSitterParser) extractSignatures(
 			}
 
 			sig.Language = opts.Language
-			sig.Exported = isExported(sig.Name, opts.Language)
 			signatures = append(signatures, sig)
 		}
 	}
@@ -502,15 +509,6 @@ func cleanComment(text string) string {
 	}
 
 	return strings.TrimSpace(text)
-}
-
-// isExported checks if a name is exported/public.
-// Currently all supported languages treat every captured signature as exported,
-// since visibility filtering is either handled by Tree-sitter queries
-// (e.g., Go package-level, TS export_statement) or deferred to the user
-// via --include-private. Returns false only for empty names.
-func isExported(name, _ string) bool {
-	return len(name) > 0
 }
 
 // stripBody removes the function/method body from the signature text.

--- a/pkg/parser/treesitter/parser_test.go
+++ b/pkg/parser/treesitter/parser_test.go
@@ -340,13 +340,14 @@ public class User {
 		t.Fatalf("Parse returned error: %v", err)
 	}
 
-	// Should have: User class, User constructor, getName method, internalMethod
-	// Private methods are now included (no private filtering)
-	if len(result.Signatures) < 4 {
-		t.Errorf("expected at least 4 signatures, got %d", len(result.Signatures))
+	// Should have: User class, User constructor, getName method
+	// Private methods are filtered out by default (internalMethod excluded)
+	if len(result.Signatures) < 3 {
+		t.Errorf("expected at least 3 signatures, got %d", len(result.Signatures))
 	}
 
-	var foundClass, foundConstructor, foundPublicMethod, foundPrivateMethod bool
+	var foundClass, foundConstructor, foundPublicMethod bool
+	foundPrivateMethod := false
 	for _, sig := range result.Signatures {
 		switch sig.Name {
 		case "User":
@@ -362,9 +363,6 @@ public class User {
 			}
 		case "internalMethod":
 			foundPrivateMethod = true
-			if sig.Kind != "method" {
-				t.Errorf("expected kind 'method', got '%s'", sig.Kind)
-			}
 		}
 	}
 
@@ -377,8 +375,8 @@ public class User {
 	if !foundPublicMethod {
 		t.Error("expected to find 'getName' method")
 	}
-	if !foundPrivateMethod {
-		t.Error("expected to find 'internalMethod' (private methods now included)")
+	if foundPrivateMethod {
+		t.Error("'internalMethod' should be filtered out (private)")
 	}
 }
 
@@ -888,14 +886,18 @@ void test() {
 		foundNames[sig.Name] = sig.Kind
 	}
 
-	// Global variables should be found as "variable"
-	globalVars := []string{"global_count", "buffer", "shared_value", "MAX_SIZE"}
+	// Global variables should be found as "variable" (non-static)
+	globalVars := []string{"global_count", "shared_value", "MAX_SIZE"}
 	for _, name := range globalVars {
 		if kind, ok := foundNames[name]; !ok {
 			t.Errorf("expected to find global variable '%s'", name)
 		} else if kind != "variable" {
 			t.Errorf("expected kind 'variable' for '%s', got '%s'", name, kind)
 		}
+	}
+	// static variables should be filtered out (file-local)
+	if _, ok := foundNames["buffer"]; ok {
+		t.Error("'buffer' is static and should be filtered out")
 	}
 
 	// Function prototype and definition should still be found as "function"
@@ -2541,21 +2543,31 @@ lazy val expensive: String = "computed"
 	expectedNames := map[string]bool{
 		"Greeter": false, "greet": false, "Shape": false,
 		"Vehicle": false, "description": false,
-		"Person": false, "helper": false,
+		"Person": false,
 		"Point": false, "distance": false,
 		"MathUtils": false, "PI": false, "counter": false, "add": false,
 		"StringList": false, "Color": false, "expensive": false,
 	}
+	// "helper" is private and should be filtered out
+	unexpectedNames := map[string]bool{"helper": false}
 
 	for _, sig := range result.Signatures {
 		if _, ok := expectedNames[sig.Name]; ok {
 			expectedNames[sig.Name] = true
+		}
+		if _, ok := unexpectedNames[sig.Name]; ok {
+			unexpectedNames[sig.Name] = true
 		}
 	}
 
 	for name, found := range expectedNames {
 		if !found {
 			t.Errorf("expected to find signature '%s'", name)
+		}
+	}
+	for name, found := range unexpectedNames {
+		if found {
+			t.Errorf("'%s' is private and should be filtered out", name)
 		}
 	}
 

--- a/pkg/parser/treesitter/query.go
+++ b/pkg/parser/treesitter/query.go
@@ -26,6 +26,11 @@ type LanguageQuery interface {
 
 	// KindMapping maps Tree-sitter node types to Signature kinds.
 	KindMapping() map[string]string
+
+	// IsExported reports whether the symbol identified by name and sigText
+	// is public/exported in the given language. sigText is the full
+	// signature text which may contain visibility modifiers.
+	IsExported(name, sigText string) bool
 }
 
 // Capture names used across all language queries.


### PR DESCRIPTION
## Summary

- `LanguageQuery` 인터페이스에 `IsExported(name, sigText string) bool` 메서드 추가
- 13개 언어에 대한 가시성 규칙 구현:
  - **Go**: 대문자 시작 = exported
  - **Python**: `_` 접두사 없음 = exported
  - **Java/PHP**: `private` 키워드 없음 = exported
  - **Kotlin/C#**: `private`/`internal` 없음 = exported
  - **Scala**: `private` 없음 = exported
  - **Swift**: `private`/`fileprivate` 없음 = exported
  - **C/C++**: `static` 접두사 없음 = exported
  - **Elixir**: `defp` 아닌 `def` = exported
  - **Rust/Ruby/TypeScript/Lua/Shell/SQL/TOML/YAML**: 기본 동작 (모두 exported)
- private 필터링을 call extraction 이후로 이동하여 caller attribution 정확도 유지
- `sig.Exported` 필드가 실제 언어 가시성 규칙 반영

Closes #263

## Test plan

- [x] `go test ./...` 전체 통과 (16개 파일 변경)
- [x] 기존 테스트 중 private 필터링 관련 테스트 업데이트
  - Java: `internalMethod` 필터링 확인
  - C: `static` 변수 필터링 확인
  - Scala: `private def helper` 필터링 확인
- [x] call extraction caller attribution 정확도 유지 (TestGoCallExtraction)