### PR TITLE
fix: MCP resolvePath 심볼릭 링크 경유 경로 탈출 방어 추가

### DIFF
--- a/cmd/brfit-mcp/main.go
+++ b/cmd/brfit-mcp/main.go
@@ -190,6 +190,7 @@ var validFormats = map[string]bool{"xml": true, "md": true, "markdown": true, "j
 // If inputPath is empty, defaultRoot is returned unchanged.
 // Absolute paths are rejected outright; relative paths are joined with
 // defaultRoot and then verified to remain within the root boundary.
+// Symlinks are resolved to prevent escaping the root via symlink targets.
 func resolvePath(defaultRoot, inputPath string) (string, error) {
 	if inputPath == "" {
 		return defaultRoot, nil
@@ -209,6 +210,27 @@ func resolvePath(defaultRoot, inputPath string) (string, error) {
 	cleanRoot := filepath.Clean(defaultRoot)
 	if absPath != cleanRoot && !strings.HasPrefix(absPath, cleanRoot+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %q resolves outside the project root %q", inputPath, defaultRoot)
+	}
+
+	// Resolve symlinks to prevent escaping the root via symlink targets.
+	// Only resolve if the path actually exists; non-existent paths are
+	// caught later by the caller's os.Stat check.
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return absPath, nil
+		}
+		return "", fmt.Errorf("failed to resolve symlinks for %q: %w", inputPath, err)
+	}
+
+	// Resolve symlinks on root as well for consistent comparison.
+	realRoot, err := filepath.EvalSymlinks(cleanRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks for root %q: %w", defaultRoot, err)
+	}
+
+	if realPath != realRoot && !strings.HasPrefix(realPath, realRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q resolves outside the project root via symlink", inputPath)
 	}
 
 	return absPath, nil

--- a/cmd/brfit-mcp/main_test.go
+++ b/cmd/brfit-mcp/main_test.go
@@ -195,6 +195,54 @@ func TestResolvePathValidRelative(t *testing.T) {
 	}
 }
 
+func TestResolvePathSymlinkEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// Create a file outside the root
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink inside root that points outside
+	symlinkPath := filepath.Join(tmpDir, "escape")
+	if err := os.Symlink(outsideDir, symlinkPath); err != nil {
+		t.Skipf("cannot create symlinks: %v", err)
+	}
+
+	_, err := resolvePath(tmpDir, "escape")
+	if err == nil {
+		t.Error("expected error for symlink escaping project root")
+	}
+	if err != nil && !strings.Contains(err.Error(), "resolves outside the project root via symlink") {
+		t.Errorf("expected symlink escape error, got: %v", err)
+	}
+}
+
+func TestResolvePathSymlinkWithinRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "real")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink within root pointing to another location within root
+	symlinkPath := filepath.Join(tmpDir, "link")
+	if err := os.Symlink(subDir, symlinkPath); err != nil {
+		t.Skipf("cannot create symlinks: %v", err)
+	}
+
+	resolved, err := resolvePath(tmpDir, "link")
+	if err != nil {
+		t.Fatalf("unexpected error for symlink within root: %v", err)
+	}
+	expected := filepath.Clean(filepath.Join(tmpDir, "link"))
+	if resolved != expected {
+		t.Errorf("expected %q, got %q", expected, resolved)
+	}
+}
+
 func TestResolvePathEmpty(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- `resolvePath()`에 `filepath.EvalSymlinks()` 추가하여 심볼릭 링크 경유 경로 탈출 방어
- 존재하지 않는 경로는 기존 동작 유지 (caller의 `os.Stat`에서 처리)
- 심볼릭 링크 탈출/허용 테스트 케이스 2개 추가

Closes #275

## Test plan
- [x] 기존 경로 순회 테스트 통과 확인
- [x] 심볼릭 링크 탈출 차단 테스트 추가 및 통과
- [x] 루트 내 심볼릭 링크 허용 테스트 추가 및 통과
- [x] 전체 MCP 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)