### PR TITLE
fix: MCP PreloadContent 대용량 프로젝트 메모리 방어

### DIFF
--- a/cmd/brfit-mcp/main.go
+++ b/cmd/brfit-mcp/main.go
@@ -263,6 +263,7 @@ func runPackager(ctx context.Context, cfg *config.Config) (*pkgcontext.Result, e
 		IncludeHidden:       cfg.IncludeHidden,
 		MaxFileSize:         cfg.MaxFileSize,
 		PreloadContent:      true,
+		MaxTotalPreloadSize: 1 << 30, // 1GB memory budget for preloaded content
 	}
 
 	packager, err := pkgcontext.NewDefaultPackager(scanOpts)

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -82,6 +82,13 @@ type ScanOptions struct {
 	// PreloadContent reads file content during scan so downstream consumers
 	// (e.g., the extractor) can skip a redundant os.ReadFile call.
 	PreloadContent bool
+
+	// MaxTotalPreloadSize limits the total bytes preloaded into memory when
+	// PreloadContent is true. Once this budget is exceeded, remaining files
+	// are included in the scan results but with Content set to nil (the
+	// extractor will fall back to on-demand os.ReadFile). A value of 0 means
+	// no limit. Default: 0.
+	MaxTotalPreloadSize int64
 }
 
 // DefaultScanOptions returns a ScanOptions with sensible defaults.
@@ -138,6 +145,7 @@ type FileScanner struct {
 	ignorerErrsWarned bool
 	logger            *log.Logger
 	rootIsFile        bool
+	preloadedSize     int64 // tracks total bytes preloaded so far
 }
 
 // NewFileScanner creates a new FileScanner with the given options.
@@ -437,12 +445,20 @@ func (s *FileScanner) checkFile(path string, info os.FileInfo) (FileEntry, bool)
 	}
 
 	if s.opts.PreloadContent {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			s.logger.Printf("WARN: failed to preload %s: %v", path, err)
-			return FileEntry{}, false
+		// Skip preloading if total preloaded size would exceed budget.
+		budget := s.opts.MaxTotalPreloadSize
+		if budget > 0 && s.preloadedSize+info.Size() > budget {
+			// Still include the file but without preloaded content;
+			// the extractor will fall back to on-demand os.ReadFile.
+		} else {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				s.logger.Printf("WARN: failed to preload %s: %v", path, err)
+				return FileEntry{}, false
+			}
+			entry.Content = content
+			s.preloadedSize += int64(len(content))
 		}
-		entry.Content = content
 	}
 
 	return entry, true

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -1221,6 +1221,45 @@ func TestPreloadContent(t *testing.T) {
 		}
 	})
 
+	t.Run("preload budget exceeded", func(t *testing.T) {
+		// Create two files; set budget so only one can be preloaded
+		goFile2 := filepath.Join(tmpDir, "other.go")
+		content2 := []byte("package main\n\nfunc Other() {}\n")
+		if err := os.WriteFile(goFile2, content2, 0644); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(goFile2)
+
+		opts := &ScanOptions{
+			RootPath:            tmpDir,
+			SupportedExtensions: defaultOpts.SupportedExtensions,
+			MaxFileSize:         defaultOpts.MaxFileSize,
+			PreloadContent:      true,
+			MaxTotalPreloadSize: int64(len(content) + 1), // just enough for 1 file
+		}
+		sc, err := NewFileScanner(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := sc.Scan(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Files) != 2 {
+			t.Fatalf("expected 2 files, got %d", len(result.Files))
+		}
+		// One file should have content, the other should not
+		preloaded := 0
+		for _, f := range result.Files {
+			if f.Content != nil {
+				preloaded++
+			}
+		}
+		if preloaded != 1 {
+			t.Errorf("expected exactly 1 preloaded file, got %d", preloaded)
+		}
+	})
+
 	t.Run("preload disabled", func(t *testing.T) {
 		opts := &ScanOptions{
 			RootPath:            tmpDir,


### PR DESCRIPTION
## Summary
- `ScanOptions`에 `MaxTotalPreloadSize` 필드 추가 (preload 메모리 예산 제한)
- 예산 초과 시 파일은 결과에 포함되지만 `Content = nil` (extractor가 on-demand 읽기)
- MCP 서버 기본 예산 1GB 설정
- 예산 초과 테스트 케이스 추가

Closes #276

## Test plan
- [x] 기존 preload 활성화/비활성화 테스트 통과
- [x] 예산 초과 테스트 추가 및 통과 (2개 파일 중 1개만 preload)
- [x] MCP 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)