### PR TITLE
perf: security.Scanner 정규식 패턴 캐싱 및 단일 패스 매칭

### DIFF
--- a/pkg/security/scanner.go
+++ b/pkg/security/scanner.go
@@ -19,21 +19,20 @@ type Pattern struct {
 	Regex *regexp.Regexp
 }
 
-// defaultPatterns returns the built-in secret detection patterns.
-func defaultPatterns() []Pattern {
-	return []Pattern{
-		{Name: "AWS Access Key ID", Regex: regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
-		{Name: "AWS Secret Access Key", Regex: regexp.MustCompile(`(?i)aws_secret_access_key\s*[=:]\s*[A-Za-z0-9/+=]{40}`)},
-		{Name: "GitHub Token", Regex: regexp.MustCompile(`gh[pousr]_[A-Za-z0-9_]{36,255}`)},
-		{Name: "Generic API Key", Regex: regexp.MustCompile(`(?i)(?:api[_-]?key|apikey)\s*[=:]\s*["']?[A-Za-z0-9_\-]{20,}["']?`)},
-		{Name: "Generic Secret", Regex: regexp.MustCompile(`(?i)\b(?:secret|password|passwd|pwd)\s*[=:]\s*["']?[^\s"']{8,}["']?`)},
-		{Name: "Bearer Token", Regex: regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9\-._~+/]{20,}=*`)},
-		{Name: "Private Key", Regex: regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----`)},
-		{Name: "Slack Token", Regex: regexp.MustCompile(`xox[bporas]-[0-9]{10,}-[A-Za-z0-9-]+`)},
-		{Name: "Google API Key", Regex: regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`)},
-		{Name: "Heroku API Key", Regex: regexp.MustCompile(`(?i)heroku.{0,100}[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)},
-		{Name: "Generic Token Assignment", Regex: regexp.MustCompile(`(?i)(?:token|auth)\s*[=:]\s*["']?[A-Za-z0-9_\-]{20,}["']?`)},
-	}
+// defaultPatterns is the built-in set of secret detection patterns.
+// Compiled once at package init to avoid repeated regexp compilation.
+var defaultPatterns = []Pattern{
+	{Name: "AWS Access Key ID", Regex: regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+	{Name: "AWS Secret Access Key", Regex: regexp.MustCompile(`(?i)aws_secret_access_key\s*[=:]\s*[A-Za-z0-9/+=]{40}`)},
+	{Name: "GitHub Token", Regex: regexp.MustCompile(`gh[pousr]_[A-Za-z0-9_]{36,255}`)},
+	{Name: "Generic API Key", Regex: regexp.MustCompile(`(?i)(?:api[_-]?key|apikey)\s*[=:]\s*["']?[A-Za-z0-9_\-]{20,}["']?`)},
+	{Name: "Generic Secret", Regex: regexp.MustCompile(`(?i)\b(?:secret|password|passwd|pwd)\s*[=:]\s*["']?[^\s"']{8,}["']?`)},
+	{Name: "Bearer Token", Regex: regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9\-._~+/]{20,}=*`)},
+	{Name: "Private Key", Regex: regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----`)},
+	{Name: "Slack Token", Regex: regexp.MustCompile(`xox[bporas]-[0-9]{10,}-[A-Za-z0-9-]+`)},
+	{Name: "Google API Key", Regex: regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`)},
+	{Name: "Heroku API Key", Regex: regexp.MustCompile(`(?i)heroku.{0,100}[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)},
+	{Name: "Generic Token Assignment", Regex: regexp.MustCompile(`(?i)(?:token|auth)\s*[=:]\s*["']?[A-Za-z0-9_\-]{20,}["']?`)},
 }
 
 // Finding represents a single secret detection finding.
@@ -64,7 +63,7 @@ type Scanner struct {
 // Warnings are written to the given writer (typically os.Stderr).
 func NewScanner(warnings io.Writer) *Scanner {
 	return &Scanner{
-		patterns: defaultPatterns(),
+		patterns: defaultPatterns,
 		warnings: warnings,
 	}
 }
@@ -138,16 +137,17 @@ func (s *Scanner) redactString(filePath, text string, sr *ScanResult) string {
 
 	result := text
 	for _, p := range s.patterns {
-		matches := p.Regex.FindAllString(result, -1)
-		if len(matches) > 0 {
-			for range matches {
-				sr.Findings = append(sr.Findings, Finding{
-					FilePath:    filePath,
-					PatternName: p.Name,
-				})
-			}
-			result = p.Regex.ReplaceAllString(result, "[REDACTED]")
-		}
+		name := p.Name
+		matched := false
+		result = p.Regex.ReplaceAllStringFunc(result, func(match string) string {
+			sr.Findings = append(sr.Findings, Finding{
+				FilePath:    filePath,
+				PatternName: name,
+			})
+			matched = true
+			return "[REDACTED]"
+		})
+		_ = matched
 	}
 
 	return result


### PR DESCRIPTION
## Summary
- `defaultPatterns`를 패키지 수준 변수로 변경하여 정규식 재컴파일 방지
- `redactString`에서 `ReplaceAllStringFunc`로 단일 패스 매칭으로 통합

Closes #258
Closes #278

## Test plan
- [x] 기존 security 테스트 11개 모두 통과
- [x] 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)