### PR TITLE
fix: PreloadContent 읽기 에러 테스트 root 권한 skip 추가

### DIFF
--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -1261,6 +1261,9 @@ func TestPreloadContent(t *testing.T) {
 	})
 
 	t.Run("preload read error falls back to nil content", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("skipping: chmod 0000 has no effect when running as root")
+		}
 		// Create a file then make it unreadable to trigger ReadFile failure.
 		unreadable := filepath.Join(tmpDir, "unreadable.go")
 		if err := os.WriteFile(unreadable, []byte("package main\n"), 0644); err != nil {


### PR DESCRIPTION
## Summary
- CI(root) 환경에서 `chmod 0000`이 ReadFile을 막지 못하는 문제 해결
- `os.Getuid() == 0` 시 테스트 skip

Closes #294

## Test plan
- [x] 로컬(non-root) 테스트 통과
- [x] CI(root)에서 skip 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)