### PR TITLE
feat: SQL DDL 이름 미추출 시 fallback 이름 생성

### DIFF
--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -457,6 +457,10 @@ func (p *TreeSitterParser) extractSignatures(
 			// (CREATE INDEX and CREATE SCHEMA have bare identifiers)
 			if opts.Language == "sql" && sig.Name == "" && sig.Text != "" {
 				sig.Name = extractSQLDDLName(sig.Text)
+				// Fallback: use DDL keyword + line number if name extraction fails
+				if sig.Name == "" {
+					sig.Name = sqlDDLFallbackName(sig.Text, sig.Line)
+				}
 			}
 		}
 
@@ -1943,6 +1947,20 @@ func stripElixirBody(text, kind string) string {
 	}
 
 	return text
+}
+
+// sqlDDLFallbackName generates a fallback name for SQL DDL statements when
+// the name cannot be extracted. It uses the DDL keyword (e.g., "INDEX",
+// "SCHEMA") plus the line number.
+func sqlDDLFallbackName(text string, line int) string {
+	upper := strings.ToUpper(text)
+	keywords := []string{"INDEX", "SCHEMA", "TABLE", "VIEW", "PROCEDURE", "FUNCTION", "TRIGGER", "SEQUENCE", "TYPE"}
+	for _, kw := range keywords {
+		if strings.Contains(upper, kw) {
+			return fmt.Sprintf("<%s:L%d>", strings.ToLower(kw), line)
+		}
+	}
+	return fmt.Sprintf("<ddl:L%d>", line)
 }
 
 // extractSQLDDLName extracts the object name from a SQL DDL statement text.


### PR DESCRIPTION
## Summary
- `sqlDDLFallbackName()` 함수 추가: DDL 키워드 + 라인 번호로 fallback 이름 생성
- `extractSQLDDLName` 실패 시 `<index:L42>` 형태로 시그니처 누락 방지

Closes #283

## Test plan
- [x] 기존 SQL 테스트 5개 모두 통과
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)