### PR TITLE
feat: 파일별 파싱 에러 리포트 개선 및 --strict 모드 추가

### DIFF
--- a/cmd/brfit/root.go
+++ b/cmd/brfit/root.go
@@ -162,6 +162,10 @@ func addFlags(cmd *cobra.Command, c *config.Config) {
 	cmd.Flags().StringVar(&c.Since, "since", c.Since,
 		"only scan files changed since the specified commit/tag (e.g., \"v1.0.0\", \"HEAD~5\")")
 
+	// Strict mode flag
+	cmd.Flags().BoolVar(&c.Strict, "strict", c.Strict,
+		"exit with error code 1 if any file has parsing errors")
+
 	// Version flag
 	cmd.Flags().BoolP("version", "v", false, "print version information")
 }
@@ -278,7 +282,18 @@ func runRoot(cmd *cobra.Command, args []string, c *config.Config) error {
 	if result.TokenCount > 0 {
 		fmt.Fprintf(os.Stderr, ", Tokens: %d", result.TokenCount)
 	}
+	if result.ErrorCount > 0 {
+		fmt.Fprintf(os.Stderr, ", Errors: %d", result.ErrorCount)
+	}
 	fmt.Fprintln(os.Stderr)
+
+	// Report parsing errors and optionally fail in strict mode
+	if result.ErrorCount > 0 {
+		fmt.Fprintf(os.Stderr, "[brfit] WARN: %d file(s) had parsing errors\n", result.ErrorCount)
+		if c.Strict {
+			return fmt.Errorf("%d file(s) had parsing errors (--strict mode)", result.ErrorCount)
+		}
+	}
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,9 @@ type Config struct {
 	// MaxDocLength is the maximum length of documentation comments in characters.
 	// 0 means no limit (default).
 	MaxDocLength int
+
+	// Strict enables strict mode where any file parsing error causes a non-zero exit code.
+	Strict bool
 }
 
 // DefaultConfig returns a Config with all default values set.

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -96,6 +96,9 @@ type Result struct {
 	// TokenCount is the number of tokens in the output.
 	// Returns 0 if token counting is disabled or tokenizer is not set.
 	TokenCount int
+
+	// ErrorCount is the number of files that had parsing errors.
+	ErrorCount int
 }
 
 // Packager orchestrates scanning, extraction, and formatting.
@@ -226,12 +229,21 @@ func (p *Packager) Package(ctx context.Context, opts *Options) (*Result, error) 
 	// 8. Calculate token count
 	tokenCount, _ := p.tokenizer.Count(content)
 
+	// 9. Count files with parsing errors
+	errorCount := 0
+	for _, ef := range extractResult.Files {
+		if ef.Error != nil {
+			errorCount++
+		}
+	}
+
 	return &Result{
 		Content:         content,
 		TotalSignatures: extractResult.TotalSignatures,
 		TotalFiles:      len(extractResult.Files),
 		TotalSize:       extractResult.TotalSize,
 		TokenCount:      tokenCount,
+		ErrorCount:      errorCount,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- `--strict` 플래그 추가: 파싱 에러 파일 존재 시 exit code 1 반환
- 기본 동작: 파싱 실패 파일 경고 출력 후 스킵 (기존 유지)
- stderr에 에러 요약 리포트 출력
- `Result.ErrorCount` 필드 추가

Closes #268

## Test plan
- [x] 빌드 성공
- [x] 전체 테스트 통과
- [ ] 수동 테스트: 지원하지 않는 파일로 `--strict` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)