### PR TITLE
refactor: Packager ErrorCount 중복 계산 제거 및 --strict 문서 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ Options:
   --since <ref>           특정 커밋/태그 이후 변경된 파일만 스캔
   --security-check        보안 민감 정보 감지 및 마스킹 (기본값: 활성화, --no-security-check으로 비활성화)
   --call-graph            함수 호출 참조 그래프 출력 (기본값: 비활성화)
+  --strict                파싱 에러 파일 존재 시 exit code 1 반환 (CI 품질 게이트용)
 ```
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,6 +34,7 @@ brfit [path] [options]
 | `--token-tree` | | Show per-file token count tree with directory totals | `false` |
 | `--security-check` / `--no-security-check` | | Detect and redact secrets in extracted code | `true` |
 | `--call-graph` | | Extract function/method call relationships per file | `false` |
+| `--strict` | | Exit with code 1 if any file has parsing errors (CI quality gate) | `false` |
 | `--version` | `-v` | Show version | |
 | `--help` | `-h` | Show help | |
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -229,21 +229,13 @@ func (p *Packager) Package(ctx context.Context, opts *Options) (*Result, error) 
 	// 8. Calculate token count
 	tokenCount, _ := p.tokenizer.Count(content)
 
-	// 9. Count files with parsing errors
-	errorCount := 0
-	for _, ef := range extractResult.Files {
-		if ef.Error != nil {
-			errorCount++
-		}
-	}
-
 	return &Result{
 		Content:         content,
 		TotalSignatures: extractResult.TotalSignatures,
 		TotalFiles:      len(extractResult.Files),
 		TotalSize:       extractResult.TotalSize,
 		TokenCount:      tokenCount,
-		ErrorCount:      errorCount,
+		ErrorCount:      extractResult.ErrorCount,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- `extractResult.ErrorCount`를 직접 사용하여 중복 루프 제거
- CLAUDE.md, docs/cli-reference.md에 `--strict` 옵션 문서 추가

Follow-up to #298 (PR review feedback)

## Test plan
- [x] 빌드 성공
- [x] context 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)