### PR TITLE
feat: XML 스키마 기본 비포함으로 변경하여 토큰 절약

### DIFF
--- a/cmd/brfit/root.go
+++ b/cmd/brfit/root.go
@@ -139,9 +139,19 @@ func addFlags(cmd *cobra.Command, c *config.Config) {
 	cmd.Flags().BoolVar(&c.TokenTree, "token-tree", c.TokenTree,
 		"output directory tree with per-file token counts")
 
-	// No schema flag
+	// Schema flags: --no-schema is kept for backwards compatibility (now default true).
+	// Use --schema to explicitly include the schema section.
 	cmd.Flags().BoolVar(&c.NoSchema, "no-schema", c.NoSchema,
-		"skip XML schema section in output")
+		"skip XML schema section in output (default: true)")
+	var includeSchema bool
+	cmd.Flags().BoolVar(&includeSchema, "schema", false,
+		"include XML schema section in output")
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("schema") && includeSchema {
+			c.NoSchema = false
+		}
+		return nil
+	}
 
 	// Call graph flag
 	cmd.Flags().BoolVar(&c.CallGraph, "call-graph", c.CallGraph,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,7 @@ func DefaultConfig() *Config {
 		SecurityCheck:  true,
 		NoTree:         false,
 		NoTokens:       false,
+		NoSchema:       true, // skip schema by default to save tokens
 		MaxFileSize:    512000, // 500KB
 		MaxDocLength:   0,      // no limit
 	}


### PR DESCRIPTION
## Summary
- `DefaultConfig()`에서 `NoSchema=true`로 변경 — 기본적으로 스키마 섹션 생략
- `--schema` 플래그 추가로 명시적 스키마 포함 가능
- 기존 `--no-schema` 플래그 유지 (하위 호환)
- 출력당 약 300+ 토큰 (3-5%) 절약

Closes #284

## Test plan
- [x] `go test ./...` 전체 통과
- [x] `TestXMLFormatterWithNoSchema` 기존 테스트 통과
- [x] `go build ./...` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)