### PR TITLE
feat: --skip-empty 플래그 추가로 빈 파일 출력 생략

### DIFF
--- a/cmd/brfit/root.go
+++ b/cmd/brfit/root.go
@@ -146,9 +146,20 @@ func addFlags(cmd *cobra.Command, c *config.Config) {
 	var includeSchema bool
 	cmd.Flags().BoolVar(&includeSchema, "schema", false,
 		"include XML schema section in output")
+
+	// Skip empty files flags: --skip-empty (default) / --no-skip-empty for backwards compatibility
+	cmd.Flags().BoolVar(&c.SkipEmpty, "skip-empty", c.SkipEmpty,
+		"omit files with no signatures/imports from output (default: true)")
+	var noSkipEmpty bool
+	cmd.Flags().BoolVar(&noSkipEmpty, "no-skip-empty", false,
+		"include files with no signatures/imports in output")
+
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("schema") && includeSchema {
 			c.NoSchema = false
+		}
+		if cmd.Flags().Changed("no-skip-empty") && noSkipEmpty {
+			c.SkipEmpty = false
 		}
 		return nil
 	}

--- a/cmd/brfit/root_test.go
+++ b/cmd/brfit/root_test.go
@@ -92,7 +92,7 @@ func TestNewRootCommand(t *testing.T) {
 	}
 
 	// Check flags exist
-	flags := []string{"mode", "format", "output", "ignore", "include", "exclude", "include-hidden", "include-private", "no-tree", "no-tokens", "max-size", "changed", "since", "token-tree", "security-check", "call-graph", "remote"}
+	flags := []string{"mode", "format", "output", "ignore", "include", "exclude", "include-hidden", "include-private", "no-tree", "no-tokens", "max-size", "changed", "since", "token-tree", "security-check", "call-graph", "remote", "skip-empty"}
 	for _, flag := range flags {
 		f := cmd.Flags().Lookup(flag)
 		if f == nil {
@@ -627,6 +627,44 @@ func TestCloneRemoteIntegration(t *testing.T) {
 	cleanup()
 	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
 		t.Error("expected temp directory to be removed after cleanup")
+	}
+}
+
+func TestSkipEmptyFlagDefault(t *testing.T) {
+	testCfg := config.DefaultConfig()
+	if !testCfg.SkipEmpty {
+		t.Error("expected SkipEmpty to be true by default")
+	}
+
+	cmd := newRootCommandWithConfig(testCfg)
+	cmd.SetArgs([]string{})
+	if err := cmd.ParseFlags([]string{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !testCfg.SkipEmpty {
+		t.Error("expected SkipEmpty to remain true after parsing empty flags")
+	}
+}
+
+func TestNoSkipEmptyFlag(t *testing.T) {
+	testCfg := config.DefaultConfig()
+	cmd := newRootCommandWithConfig(testCfg)
+
+	// Parse flags (including --no-skip-empty)
+	if err := cmd.ParseFlags([]string{"--no-skip-empty"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually trigger PreRunE to apply flag logic
+	if cmd.PreRunE != nil {
+		if err := cmd.PreRunE(cmd, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if testCfg.SkipEmpty {
+		t.Error("expected SkipEmpty to be false after --no-skip-empty")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,9 @@ type Config struct {
 
 	// Strict enables strict mode where any file parsing error causes a non-zero exit code.
 	Strict bool
+
+	// SkipEmpty omits files with no signatures/imports from the output entirely.
+	SkipEmpty bool
 }
 
 // DefaultConfig returns a Config with all default values set.
@@ -111,6 +114,7 @@ func DefaultConfig() *Config {
 		NoSchema:       true, // skip schema by default to save tokens
 		MaxFileSize:    512000, // 500KB
 		MaxDocLength:   0,      // no limit
+		SkipEmpty:      true,
 	}
 }
 
@@ -197,5 +201,6 @@ func (c *Config) ToOptions() *pkgcontext.Options {
 		NoSchema:         c.NoSchema,
 		SecurityCheck:    c.SecurityCheck,
 		IncludeCallGraph: c.CallGraph,
+		SkipEmpty:        c.SkipEmpty,
 	}
 }

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -65,6 +65,9 @@ type Options struct {
 
 	// IncludeCallGraph enables function call graph extraction.
 	IncludeCallGraph bool
+
+	// SkipEmpty omits files with no signatures/imports from the output entirely.
+	SkipEmpty bool
 }
 
 // DefaultOptions returns Options with sensible defaults.
@@ -214,6 +217,7 @@ func (p *Packager) Package(ctx context.Context, opts *Options) (*Result, error) 
 		MaxDocLength:     opts.MaxDocLength,
 		NoSchema:         opts.NoSchema,
 		IncludeCallGraph: opts.IncludeCallGraph,
+		SkipEmpty:        opts.SkipEmpty,
 	}
 
 	// 6. Get formatter (normalize format and fallback to xml)

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -66,6 +66,9 @@ type PackageData struct {
 
 	// IncludeCallGraph indicates whether to include function call references.
 	IncludeCallGraph bool
+
+	// SkipEmpty omits files with no signatures/imports from the output entirely.
+	SkipEmpty bool
 }
 
 // ImportCount represents an import with its usage count across files.

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -754,6 +754,192 @@ func TestJSONFormatterName(t *testing.T) {
 	}
 }
 
+func TestXMLFormatterSkipEmpty(t *testing.T) {
+	formatter := NewXMLFormatter()
+	data := &PackageData{
+		SkipEmpty: true,
+		Files: []FileData{
+			{
+				Path:       "empty.go",
+				Language:   "go",
+				Signatures: []parser.Signature{},
+			},
+			{
+				Path:     "notempty.go",
+				Language: "go",
+				Signatures: []parser.Signature{
+					{Name: "Foo", Kind: "function", Text: "func Foo()"},
+				},
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	if strings.Contains(outputStr, `path="empty.go"`) {
+		t.Error("expected empty file to be skipped with SkipEmpty=true")
+	}
+	if !strings.Contains(outputStr, `path="notempty.go"`) {
+		t.Error("expected non-empty file to be present")
+	}
+	if strings.Contains(outputStr, "<!-- empty -->") {
+		t.Error("expected no <!-- empty --> comment with SkipEmpty=true")
+	}
+}
+
+func TestXMLFormatterSkipEmptyKeepsErrors(t *testing.T) {
+	formatter := NewXMLFormatter()
+	data := &PackageData{
+		SkipEmpty: true,
+		Files: []FileData{
+			{
+				Path:     "error.go",
+				Language: "go",
+				Error:    fmt.Errorf("parse error"),
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "error.go") {
+		t.Error("expected error file to be present even with SkipEmpty=true")
+	}
+	if !strings.Contains(outputStr, "<error>parse error</error>") {
+		t.Error("expected error element")
+	}
+}
+
+func TestXMLFormatterNoSkipEmpty(t *testing.T) {
+	formatter := NewXMLFormatter()
+	data := &PackageData{
+		SkipEmpty: false,
+		Files: []FileData{
+			{
+				Path:       "empty.go",
+				Language:   "go",
+				Signatures: []parser.Signature{},
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, `path="empty.go"`) {
+		t.Error("expected empty file to be present with SkipEmpty=false")
+	}
+	if !strings.Contains(outputStr, "<!-- empty -->") {
+		t.Error("expected <!-- empty --> comment with SkipEmpty=false")
+	}
+}
+
+func TestMarkdownFormatterSkipEmpty(t *testing.T) {
+	formatter := NewMarkdownFormatter()
+	data := &PackageData{
+		SkipEmpty: true,
+		Files: []FileData{
+			{
+				Path:       "empty.go",
+				Language:   "go",
+				Signatures: []parser.Signature{},
+			},
+			{
+				Path:     "notempty.go",
+				Language: "go",
+				Signatures: []parser.Signature{
+					{Name: "Foo", Kind: "function", Text: "func Foo()"},
+				},
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	if strings.Contains(outputStr, "### empty.go\n") {
+		t.Error("expected empty file to be skipped with SkipEmpty=true")
+	}
+	if !strings.Contains(outputStr, "### notempty.go") {
+		t.Error("expected non-empty file to be present")
+	}
+}
+
+func TestJSONFormatterSkipEmpty(t *testing.T) {
+	formatter := NewJSONFormatter()
+	data := &PackageData{
+		SkipEmpty: true,
+		Files: []FileData{
+			{
+				Path:       "empty.go",
+				Language:   "go",
+				Signatures: []parser.Signature{},
+			},
+			{
+				Path:     "notempty.go",
+				Language: "go",
+				Signatures: []parser.Signature{
+					{Name: "Foo", Kind: "function", Text: "func Foo()"},
+				},
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	if strings.Contains(outputStr, `"path":"empty.go"`) {
+		t.Error("expected empty file to be skipped with SkipEmpty=true")
+	}
+	if !strings.Contains(outputStr, `"path":"notempty.go"`) {
+		t.Error("expected non-empty file to be present")
+	}
+}
+
+func TestXMLFormatterSkipEmptyWithImports(t *testing.T) {
+	formatter := NewXMLFormatter()
+	data := &PackageData{
+		SkipEmpty:      true,
+		IncludeImports: true,
+		Files: []FileData{
+			{
+				Path:       "with_imports.go",
+				Language:   "go",
+				Signatures: []parser.Signature{},
+				RawImports: []string{`import "fmt"`},
+			},
+		},
+	}
+
+	output, err := formatter.Format(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputStr := string(output)
+	// File has imports, so it should NOT be skipped
+	if !strings.Contains(outputStr, "with_imports.go") {
+		t.Error("expected file with imports to be present even with SkipEmpty=true")
+	}
+}
+
 func TestXMLFormatterWithNoSchema(t *testing.T) {
 	formatter := NewXMLFormatter()
 	data := &PackageData{

--- a/pkg/formatter/json.go
+++ b/pkg/formatter/json.go
@@ -79,6 +79,14 @@ func (f *JSONFormatter) Format(data *PackageData) ([]byte, error) {
 	}
 
 	for _, file := range data.Files {
+		// SkipEmpty: 빈 파일 건너뜀
+		if data.SkipEmpty && file.Error == nil {
+			hasImports := data.IncludeImports && len(file.RawImports) > 0 && !data.DedupeImports
+			if len(file.Signatures) == 0 && !hasImports {
+				continue
+			}
+		}
+
 		jf := jsonFile{
 			Path:     file.Path,
 			Language: file.Language,

--- a/pkg/formatter/markdown.go
+++ b/pkg/formatter/markdown.go
@@ -65,24 +65,29 @@ func (f *MarkdownFormatter) Format(data *PackageData) ([]byte, error) {
 	// Files
 	buf.WriteString("## Files\n\n")
 	for _, file := range data.Files {
-		buf.WriteString("### ")
-		buf.WriteString(file.Path)
-		buf.WriteString("\n\n")
-
 		// Imports (within file block) - only if not deduping
 		hasRenderedImports := false
 		if file.Error == nil && data.IncludeImports && len(file.RawImports) > 0 && !data.DedupeImports {
 			hasRenderedImports = true
 		}
 
+		// 빈 파일 확인
+		isEmpty := file.Error == nil && len(file.Signatures) == 0 && !hasRenderedImports
+
+		// SkipEmpty가 true이면 빈 파일 전체를 건너뜀
+		if data.SkipEmpty && isEmpty {
+			continue
+		}
+
+		buf.WriteString("### ")
+		buf.WriteString(file.Path)
+		buf.WriteString("\n\n")
+
 		if file.Error != nil {
 			buf.WriteString("> **Error:** ")
 			buf.WriteString(escapeMarkdown(file.Error.Error()))
 			buf.WriteString("\n\n")
 		} else {
-			// 빈 파일 확인
-			isEmpty := len(file.Signatures) == 0 && !hasRenderedImports
-
 			buf.WriteString("```")
 			buf.WriteString(file.Language)
 			buf.WriteByte('\n')

--- a/pkg/formatter/xml.go
+++ b/pkg/formatter/xml.go
@@ -79,16 +79,28 @@ func (f *XMLFormatter) Format(data *PackageData) ([]byte, error) {
 	// Files section
 	buf.WriteString("  <files>\n")
 	for _, file := range data.Files {
+		// Imports section (within file block)
+		hasRenderedImports := false
+		if file.Error == nil && data.IncludeImports && len(file.RawImports) > 0 {
+			hasRenderedImports = true
+		}
+
+		// 빈 파일 확인
+		isEmpty := file.Error == nil && len(file.Signatures) == 0 && !hasRenderedImports
+
+		// SkipEmpty가 true이면 빈 파일 전체를 건너뜀
+		if data.SkipEmpty && isEmpty {
+			continue
+		}
+
 		buf.WriteString("    <file path=\"")
 		buf.WriteString(escapeXML(file.Path))
 		buf.WriteString("\" language=\"")
 		buf.WriteString(escapeXML(file.Language))
 		buf.WriteString("\">\n")
 
-		// Imports section (within file block)
-		hasRenderedImports := false
-		if file.Error == nil && data.IncludeImports && len(file.RawImports) > 0 {
-			hasRenderedImports = true
+		// Render imports
+		if hasRenderedImports {
 			buf.WriteString("      <imports>")
 			buf.WriteString(escapeXML(strings.Join(file.RawImports, "\n")))
 			buf.WriteString("</imports>\n")
@@ -99,9 +111,6 @@ func (f *XMLFormatter) Format(data *PackageData) ([]byte, error) {
 			buf.WriteString(escapeXML(file.Error.Error()))
 			buf.WriteString("</error>\n")
 		} else {
-			// 빈 파일 확인
-			isEmpty := len(file.Signatures) == 0 && !hasRenderedImports
-
 			if isEmpty {
 				buf.WriteString("      <!-- empty -->\n")
 			} else {


### PR DESCRIPTION
## Summary
- Add `--skip-empty` CLI flag (default: `true`) that omits files with no signatures/imports from output entirely
- Add `--no-skip-empty` flag for backwards compatibility to show `<!-- empty -->` comments
- Applies to all three formatters: XML, Markdown, JSON

## Changes
- `internal/config/config.go`: Add `SkipEmpty` field to Config struct (default: true)
- `internal/context/context.go`: Add `SkipEmpty` to Options, pass through to PackageData
- `pkg/formatter/formatter.go`: Add `SkipEmpty` field to PackageData
- `pkg/formatter/xml.go`: Skip `<file>` element when SkipEmpty=true and file is empty
- `pkg/formatter/markdown.go`: Skip file section when SkipEmpty=true and file is empty
- `pkg/formatter/json.go`: Skip file entry when SkipEmpty=true and file is empty
- `cmd/brfit/root.go`: Add `--skip-empty` / `--no-skip-empty` flags
- Tests for all formatters and CLI flag parsing

Closes #285

## Test plan
- [x] `go test ./...` passes
- [x] XML formatter skips empty files when SkipEmpty=true
- [x] XML formatter keeps error files even when SkipEmpty=true
- [x] XML formatter shows `<!-- empty -->` when SkipEmpty=false
- [x] XML formatter keeps files with imports when SkipEmpty=true
- [x] Markdown formatter skips empty files when SkipEmpty=true
- [x] JSON formatter skips empty files when SkipEmpty=true
- [x] `--skip-empty` flag defaults to true
- [x] `--no-skip-empty` flag sets SkipEmpty=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)