### PR TITLE
feat: MCP list_languages 도구 추가

### DIFF
--- a/cmd/brfit-mcp/main.go
+++ b/cmd/brfit-mcp/main.go
@@ -27,8 +27,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"sort"
+
 	"github.com/indigo-net/Brf.it/internal/config"
 	pkgcontext "github.com/indigo-net/Brf.it/internal/context"
+	"github.com/indigo-net/Brf.it/pkg/parser"
 	"github.com/indigo-net/Brf.it/pkg/scanner"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -70,6 +73,12 @@ func main() {
 		Name:        "summarize_file",
 		Description: "Extract function signatures and documentation from specific files matching a glob pattern.",
 	}, makeSummarizeFile(absRoot))
+
+	// Tool: list_languages
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_languages",
+		Description: "List all programming languages supported by brfit for code analysis.",
+	}, handleListLanguages)
 
 	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		fmt.Fprintf(os.Stderr, "server error: %v\n", err)
@@ -180,6 +189,26 @@ func makeSummarizeFile(defaultRoot string) func(context.Context, *mcp.CallToolRe
 			TotalSignatures: result.TotalSignatures,
 		}, nil
 	}
+}
+
+// ListLanguagesInput defines the input for the list_languages tool.
+// No required parameters.
+type ListLanguagesInput struct{}
+
+// ListLanguagesOutput defines the output for the list_languages tool.
+type ListLanguagesOutput struct {
+	Languages []string `json:"languages" jsonschema:"list of supported language names"`
+	Count     int      `json:"count" jsonschema:"number of supported languages"`
+}
+
+// handleListLanguages returns the list of supported programming languages.
+func handleListLanguages(_ context.Context, _ *mcp.CallToolRequest, _ ListLanguagesInput) (*mcp.CallToolResult, ListLanguagesOutput, error) {
+	langs := parser.DefaultRegistry().Languages()
+	sort.Strings(langs)
+	return nil, ListLanguagesOutput{
+		Languages: langs,
+		Count:     len(langs),
+	}, nil
 }
 
 // validFormats is the set of accepted output format values.

--- a/cmd/brfit-mcp/main_test.go
+++ b/cmd/brfit-mcp/main_test.go
@@ -71,6 +71,40 @@ func TestSummarizeFile(t *testing.T) {
 	}
 }
 
+func TestListLanguages(t *testing.T) {
+	_, output, err := handleListLanguages(context.Background(), &mcp.CallToolRequest{}, ListLanguagesInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.Count == 0 {
+		t.Error("expected at least 1 supported language")
+	}
+	if len(output.Languages) != output.Count {
+		t.Errorf("languages length %d does not match count %d", len(output.Languages), output.Count)
+	}
+
+	// Verify languages are sorted
+	for i := 1; i < len(output.Languages); i++ {
+		if output.Languages[i] < output.Languages[i-1] {
+			t.Errorf("languages not sorted: %q before %q", output.Languages[i-1], output.Languages[i])
+			break
+		}
+	}
+
+	// Verify Go is in the list (since we import treesitter parsers)
+	found := false
+	for _, lang := range output.Languages {
+		if lang == "go" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'go' in languages list, got: %v", output.Languages)
+	}
+}
+
 func TestSummarizeProjectInvalidPath(t *testing.T) {
 	handler := makeSummarizeProject("/nonexistent/path")
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SummarizeProjectInput{})


### PR DESCRIPTION
## Summary
- MCP 서버에 `list_languages` 도구 추가: 지원 프로그래밍 언어 목록을 JSON으로 반환
- `parser.DefaultRegistry().Languages()` 호출하여 등록된 언어 목록과 개수 반환
- 테스트 추가: 정렬 확인, Go 언어 포함 확인, count 일치 확인

Closes #271

## Test plan
- [x] `TestListLanguages` 추가 및 통과 확인
- [x] `go test ./...` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)