### PR TITLE
docs: README에 아키텍처 섹션 추가 (5개 언어)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,35 @@ export async function fetchUser(
 
 <br/>
 
+## Architecture
+
+`brfit` is a five-stage pipeline. One orchestrator — `Packager.Package()` in `internal/context` — runs your files through each stage:
+
+```mermaid
+flowchart LR
+    Files --> Scanner --> Extractor --> Security --> Formatter --> Tokenizer --> Output["XML / MD / JSON"]
+    Extractor -. uses .-> Parser["Parser × 19 languages"]
+```
+
+| Stage | Package | Responsibility |
+|-------|---------|----------------|
+| Scanner | `pkg/scanner` | Selects which files to read (.gitignore, glob, size filters) |
+| Extractor | `pkg/extractor` | Runs files through the right parser concurrently (worker pool) |
+| Parser | `pkg/parser` | Parses one file via Tree-sitter, extracts signatures (19 languages) |
+| Security | `pkg/security` | Detects and redacts secrets |
+| Formatter | `pkg/formatter` | Renders output as XML / Markdown / JSON |
+| Tokenizer | `pkg/tokenizer` | Counts output tokens |
+
+**Design principles**
+
+- **Interface-first.** `Scanner`, `Extractor`, `Parser`, and `Formatter` are interfaces. Adding a language, format, or CLI flag means filling a slot — not rewiring the core.
+- **Extractor → Parser boundary.** The Extractor handles scale (concurrency, I/O, error aggregation); each Parser handles one language. They connect loosely through a **Registry**, so a new language never touches the Extractor.
+- **Two entry points, one core.** `cmd/brfit` (CLI) and `cmd/brfit-mcp` (MCP server) share the same `pkg/` packages.
+
+---
+
+<br/>
+
 ## Quick Start
 
 ### Installation

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -75,6 +75,35 @@ export async function fetchUser(
 
 <br/>
 
+## Architektur
+
+`brfit` ist eine fünfstufige Pipeline. Ein Orchestrator – `Packager.Package()` in `internal/context` – führt Ihre Dateien durch jede Stufe:
+
+```mermaid
+flowchart LR
+    Files --> Scanner --> Extractor --> Security --> Formatter --> Tokenizer --> Output["XML / MD / JSON"]
+    Extractor -. uses .-> Parser["Parser × 19 languages"]
+```
+
+| Stufe | Paket | Aufgabe |
+|-------|-------|---------|
+| Scanner | `pkg/scanner` | Wählt zu lesende Dateien aus (.gitignore, glob, Größenfilter) |
+| Extractor | `pkg/extractor` | Führt Dateien nebenläufig durch den passenden Parser (Worker-Pool) |
+| Parser | `pkg/parser` | Parst eine Datei via Tree-sitter, extrahiert Signaturen (19 Sprachen) |
+| Security | `pkg/security` | Erkennt und maskiert Geheimnisse |
+| Formatter | `pkg/formatter` | Rendert Ausgabe als XML / Markdown / JSON |
+| Tokenizer | `pkg/tokenizer` | Zählt Ausgabe-Tokens |
+
+**Designprinzipien**
+
+- **Interface-first.** `Scanner`, `Extractor`, `Parser` und `Formatter` sind Interfaces. Eine Sprache, ein Format oder ein CLI-Flag hinzuzufügen bedeutet, einen Platz zu füllen – nicht den Kern umzubauen.
+- **Grenze Extractor → Parser.** Der Extractor kümmert sich um Skalierung (Nebenläufigkeit, I/O, Fehleraggregation); jeder Parser um eine Sprache. Sie sind über eine **Registry** lose gekoppelt, sodass eine neue Sprache den Extractor nie berührt.
+- **Zwei Einstiegspunkte, ein Kern.** `cmd/brfit` (CLI) und `cmd/brfit-mcp` (MCP-Server) teilen sich dieselben `pkg/`-Pakete.
+
+---
+
+<br/>
+
 ## Schnellstart
 
 ### Installation

--- a/docs/hi/README.md
+++ b/docs/hi/README.md
@@ -75,6 +75,35 @@ export async function fetchUser(
 
 <br/>
 
+## आर्किटेक्चर
+
+`brfit` एक पाँच-चरण पाइपलाइन है। एक ऑर्केस्ट्रेटर — `internal/context` में `Packager.Package()` — आपकी फ़ाइलों को हर चरण से गुज़ारता है:
+
+```mermaid
+flowchart LR
+    Files --> Scanner --> Extractor --> Security --> Formatter --> Tokenizer --> Output["XML / MD / JSON"]
+    Extractor -. uses .-> Parser["Parser × 19 languages"]
+```
+
+| चरण | पैकेज | ज़िम्मेदारी |
+|------|-------|-------------|
+| Scanner | `pkg/scanner` | पढ़ने योग्य फ़ाइलें चुनता है (.gitignore, glob, आकार फ़िल्टर) |
+| Extractor | `pkg/extractor` | फ़ाइलों को सही पार्सर से समानांतर चलाता है (वर्कर पूल) |
+| Parser | `pkg/parser` | Tree-sitter से एक फ़ाइल पार्स कर सिग्नेचर निकालता है (19 भाषाएँ) |
+| Security | `pkg/security` | सीक्रेट्स का पता लगाकर छिपाता है |
+| Formatter | `pkg/formatter` | आउटपुट को XML / Markdown / JSON में रेंडर करता है |
+| Tokenizer | `pkg/tokenizer` | आउटपुट टोकन गिनता है |
+
+**डिज़ाइन सिद्धांत**
+
+- **इंटरफ़ेस-प्रथम।** `Scanner`, `Extractor`, `Parser` और `Formatter` सभी इंटरफ़ेस हैं। भाषा, फ़ॉर्मेट या CLI फ़्लैग जोड़ना कोर को दोबारा बनाना नहीं, बल्कि एक तयशुदा जगह भरना है।
+- **Extractor → Parser सीमा।** Extractor स्केल (समानांतरता, I/O, एरर एकत्रीकरण) संभालता है; हर Parser एक भाषा। वे **Registry** के ज़रिए ढीले-ढाले जुड़े हैं, इसलिए नई भाषा जोड़ने पर Extractor को छूना नहीं पड़ता।
+- **दो प्रवेश-बिंदु, एक कोर।** `cmd/brfit` (CLI) और `cmd/brfit-mcp` (MCP सर्वर) एक ही `pkg/` पैकेज साझा करते हैं।
+
+---
+
+<br/>
+
 ## क्विक स्टार्ट
 
 ### इंस्टॉलेशन

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -75,6 +75,35 @@ export async function fetchUser(
 
 <br/>
 
+## アーキテクチャ
+
+`brfit` は5段階のパイプラインです。1つのオーケストレーター（`internal/context` の `Packager.Package()`）がファイルを各段階に通します：
+
+```mermaid
+flowchart LR
+    Files --> Scanner --> Extractor --> Security --> Formatter --> Tokenizer --> Output["XML / MD / JSON"]
+    Extractor -. uses .-> Parser["Parser × 19 languages"]
+```
+
+| 段階 | パッケージ | 役割 |
+|------|-----------|------|
+| Scanner | `pkg/scanner` | 読み込むファイルを選別（.gitignore、glob、サイズフィルタ） |
+| Extractor | `pkg/extractor` | ファイルを適切なパーサーで並行処理（ワーカープール） |
+| Parser | `pkg/parser` | Tree-sitter で1ファイルを解析しシグネチャを抽出（19言語） |
+| Security | `pkg/security` | シークレットの検出とマスキング |
+| Formatter | `pkg/formatter` | XML / Markdown / JSON で出力を整形 |
+| Tokenizer | `pkg/tokenizer` | 出力トークン数をカウント |
+
+**設計原則**
+
+- **インターフェース優先。** `Scanner`、`Extractor`、`Parser`、`Formatter` はすべてインターフェースです。言語・フォーマット・CLIフラグの追加は、コアを作り直すのではなく、決められた枠を埋める作業です。
+- **Extractor → Parser の境界。** Extractor はスケール（並行処理、I/O、エラー集約）を担い、各 Parser は1つの言語を担います。両者は **Registry** を介して疎結合しているため、新しい言語を追加しても Extractor には触れません。
+- **2つのエントリーポイント、1つのコア。** `cmd/brfit`（CLI）と `cmd/brfit-mcp`（MCPサーバー）は同じ `pkg/` パッケージを共有します。
+
+---
+
+<br/>
+
 ## クイックスタート
 
 ### インストール

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -75,6 +75,35 @@ export async function fetchUser(
 
 <br/>
 
+## 아키텍처
+
+`brfit`은 5단계 파이프라인입니다. 하나의 오케스트레이터(`internal/context`의 `Packager.Package()`)가 파일을 각 단계에 통과시킵니다:
+
+```mermaid
+flowchart LR
+    Files --> Scanner --> Extractor --> Security --> Formatter --> Tokenizer --> Output["XML / MD / JSON"]
+    Extractor -. uses .-> Parser["Parser × 19 languages"]
+```
+
+| 단계 | 패키지 | 역할 |
+|------|--------|------|
+| Scanner | `pkg/scanner` | 읽을 파일 선별 (.gitignore, glob, 크기 필터) |
+| Extractor | `pkg/extractor` | 파일을 알맞은 파서로 동시 처리 (워커 풀) |
+| Parser | `pkg/parser` | Tree-sitter로 파일 하나를 파싱해 시그니처 추출 (19개 언어) |
+| Security | `pkg/security` | 시크릿 감지 및 마스킹 |
+| Formatter | `pkg/formatter` | XML / Markdown / JSON으로 출력 렌더링 |
+| Tokenizer | `pkg/tokenizer` | 출력 토큰 수 계산 |
+
+**설계 원칙**
+
+- **인터페이스 우선.** `Scanner`, `Extractor`, `Parser`, `Formatter`는 모두 인터페이스입니다. 언어·포맷·CLI 플래그 추가는 코어를 뜯어고치는 게 아니라 정해진 자리를 채우는 일입니다.
+- **Extractor → Parser 경계.** Extractor는 규모(동시성, I/O, 에러 집계)를 담당하고, 각 Parser는 언어 하나를 담당합니다. 둘은 **Registry**를 통해 느슨하게 연결되므로, 새 언어를 추가해도 Extractor는 건드리지 않습니다.
+- **두 진입점, 하나의 코어.** `cmd/brfit`(CLI)와 `cmd/brfit-mcp`(MCP 서버)는 동일한 `pkg/` 패키지를 공유합니다.
+
+---
+
+<br/>
+
 ## 빠른 시작
 
 ### 설치


### PR DESCRIPTION
## 개요

README에 프로젝트 내부 아키텍처를 설명하는 `Architecture` 섹션을 추가합니다. `How It Works`(가치 제안)와 `Quick Start`(설치) 사이에 위치하여, 기여자·유지보수자가 전체 구조를 빠르게 파악할 수 있게 합니다.

## 내용

- **mermaid 파이프라인 다이어그램** — Scanner → Extractor → Security → Formatter → Tokenizer 흐름 + Extractor가 Parser(19개 언어)를 사용하는 관계 (GitHub 자동 렌더)
- **패키지 역할표** — 각 `pkg/` 패키지의 단계별 책임
- **설계 원칙 3가지**
  - 인터페이스 우선 (Scanner/Extractor/Parser/Formatter)
  - Extractor → Parser 경계 (규모 vs 언어 지식, Registry로 느슨한 연결)
  - 두 진입점(`cmd/brfit`, `cmd/brfit-mcp`), 하나의 코어(`pkg/`)

## 동기화

프로젝트 규칙에 따라 **5개 언어 README 전부** 동기화:
- `README.md` (영어 원본)
- `docs/ko`, `docs/ja`, `docs/de`, `docs/hi`

## 검증

- 헤딩 순서: `How It Works → Architecture → Quick Start` (5개 파일 동일)
- mermaid 코드블록 5개 정상 삽입
- ⚠️ mermaid 렌더링은 GitHub 병합/미리보기에서 최종 확인 필요