### PR TITLE
fix: doc 주석을 시그니처에 연결하여 <doc> 출력 복구 (#322)

### DIFF
--- a/pkg/formatter/doc_render_test.go
+++ b/pkg/formatter/doc_render_test.go
@@ -1,0 +1,45 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// TestMarkdownFormatterMultiLineDocQuoted verifies that every line of a
+// multi-line doc comment is prefixed with the blockquote marker, so the
+// rendered Markdown does not break out of the quote after the first line.
+func TestMarkdownFormatterMultiLineDocQuoted(t *testing.T) {
+	f := NewMarkdownFormatter()
+	data := &PackageData{
+		Files: []FileData{
+			{
+				Path:     "test.go",
+				Language: "go",
+				Signatures: []parser.Signature{
+					{
+						Name:     "Add",
+						Kind:     "function",
+						Text:     "func Add(a, b int) int",
+						Doc:      "Add sums two ints.\nSecond line of docs.",
+						Line:     1,
+						Language: "go",
+						Exported: true,
+					},
+				},
+			},
+		},
+		TotalSignatures: 1,
+	}
+
+	out, err := f.Format(data)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	want := "> Add sums two ints.\n> Second line of docs."
+	if !strings.Contains(string(out), want) {
+		t.Errorf("multi-line doc not fully quoted;\nwant to contain: %q\ngot:\n%s", want, out)
+	}
+}

--- a/pkg/formatter/markdown.go
+++ b/pkg/formatter/markdown.go
@@ -114,9 +114,14 @@ func (f *MarkdownFormatter) Format(data *PackageData) ([]byte, error) {
 			if !isEmpty {
 				for _, sig := range file.Signatures {
 					if sig.Doc != "" {
-						buf.WriteString("> ")
-						buf.WriteString(escapeMarkdown(truncateDoc(sig.Doc, data.MaxDocLength)))
-						buf.WriteString("\n")
+						// Prefix every line with the blockquote marker so
+						// multi-line docs stay inside the quote.
+						doc := truncateDoc(sig.Doc, data.MaxDocLength)
+						for _, line := range strings.Split(doc, "\n") {
+							buf.WriteString("> ")
+							buf.WriteString(escapeMarkdown(line))
+							buf.WriteString("\n")
+						}
 					}
 				}
 			}

--- a/pkg/parser/treesitter/doc_test.go
+++ b/pkg/parser/treesitter/doc_test.go
@@ -1,0 +1,108 @@
+package treesitter
+
+import (
+	"testing"
+
+	"github.com/indigo-net/Brf.it/pkg/parser"
+)
+
+// TestParseAttachesDocComment verifies that a documentation comment
+// immediately preceding a declaration is attached to that signature's Doc.
+func TestParseAttachesDocComment(t *testing.T) {
+	code := []byte(`package main
+
+// Greet returns a friendly greeting for the given name.
+func Greet(name string) string {
+	return "hi " + name
+}
+`)
+
+	p := NewTreeSitterParser()
+	result, err := p.Parse(code, &parser.Options{Language: "go"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var greet *parser.Signature
+	for i := range result.Signatures {
+		if result.Signatures[i].Name == "Greet" {
+			greet = &result.Signatures[i]
+			break
+		}
+	}
+	if greet == nil {
+		t.Fatalf("Greet signature not found; got %d signatures", len(result.Signatures))
+	}
+
+	want := "Greet returns a friendly greeting for the given name."
+	if greet.Doc != want {
+		t.Errorf("Doc not attached: got %q, want %q", greet.Doc, want)
+	}
+}
+
+// TestParseAttachesMultiLineDoc verifies that a contiguous run of single-line
+// comments above a declaration is joined into that signature's Doc.
+func TestParseAttachesMultiLineDoc(t *testing.T) {
+	code := []byte(`package main
+
+// Add returns the sum of two integers.
+// It is used in the arithmetic examples.
+func Add(a, b int) int {
+	return a + b
+}
+`)
+
+	p := NewTreeSitterParser()
+	result, err := p.Parse(code, &parser.Options{Language: "go"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var add *parser.Signature
+	for i := range result.Signatures {
+		if result.Signatures[i].Name == "Add" {
+			add = &result.Signatures[i]
+			break
+		}
+	}
+	if add == nil {
+		t.Fatalf("Add signature not found; got %d signatures", len(result.Signatures))
+	}
+
+	want := "Add returns the sum of two integers.\nIt is used in the arithmetic examples."
+	if add.Doc != want {
+		t.Errorf("multi-line Doc not joined: got %q, want %q", add.Doc, want)
+	}
+}
+
+// TestParseDoesNotAttachSeparatedComment verifies that a comment separated from
+// a declaration by a blank line is NOT attached (matches godoc semantics).
+func TestParseDoesNotAttachSeparatedComment(t *testing.T) {
+	code := []byte(`package main
+
+// This is a stray comment, not documentation.
+
+func Lonely() {}
+`)
+
+	p := NewTreeSitterParser()
+	result, err := p.Parse(code, &parser.Options{Language: "go"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var lonely *parser.Signature
+	for i := range result.Signatures {
+		if result.Signatures[i].Name == "Lonely" {
+			lonely = &result.Signatures[i]
+			break
+		}
+	}
+	if lonely == nil {
+		t.Fatalf("Lonely signature not found; got %d signatures", len(result.Signatures))
+	}
+
+	if lonely.Doc != "" {
+		t.Errorf("separated comment should not attach: got Doc=%q", lonely.Doc)
+	}
+}

--- a/pkg/parser/treesitter/doc_test.go
+++ b/pkg/parser/treesitter/doc_test.go
@@ -106,3 +106,63 @@ func Lonely() {}
 		t.Errorf("separated comment should not attach: got Doc=%q", lonely.Doc)
 	}
 }
+
+// TestParseDoesNotAttachTrailingComment verifies that a trailing/inline comment
+// on a declaration line is not mistaken for the following declaration's doc.
+func TestParseDoesNotAttachTrailingComment(t *testing.T) {
+	code := []byte(`package main
+
+func Foo() {} // trailing note about Foo
+func Bar() {}
+`)
+
+	p := NewTreeSitterParser()
+	result, err := p.Parse(code, &parser.Options{Language: "go"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	byName := map[string]string{}
+	for i := range result.Signatures {
+		byName[result.Signatures[i].Name] = result.Signatures[i].Doc
+	}
+
+	if got := byName["Bar"]; got != "" {
+		t.Errorf("trailing comment leaked onto next declaration: Bar.Doc=%q", got)
+	}
+	if got := byName["Foo"]; got != "" {
+		t.Errorf("trailing comment should not be Foo's doc either: Foo.Doc=%q", got)
+	}
+}
+
+// TestParseAttachesBlockDoc verifies that a leading block comment (/* ... */) is
+// attached as the following declaration's doc.
+func TestParseAttachesBlockDoc(t *testing.T) {
+	code := []byte(`package main
+
+/* Widget builds a widget. */
+func Widget() {}
+`)
+
+	p := NewTreeSitterParser()
+	result, err := p.Parse(code, &parser.Options{Language: "go"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var widget *parser.Signature
+	for i := range result.Signatures {
+		if result.Signatures[i].Name == "Widget" {
+			widget = &result.Signatures[i]
+			break
+		}
+	}
+	if widget == nil {
+		t.Fatalf("Widget signature not found; got %d signatures", len(result.Signatures))
+	}
+
+	want := "Widget builds a widget."
+	if widget.Doc != want {
+		t.Errorf("block doc not attached: got %q, want %q", widget.Doc, want)
+	}
+}

--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -304,6 +304,12 @@ func (p *TreeSitterParser) extractSignatures(
 	}
 	seen := make(map[dedupKey]bool)
 
+	// Collect standalone comment matches so they can be attached to the
+	// signatures they precede (see attachDocs). Every language captures
+	// comments as an independent (comment) @doc pattern, so they arrive as
+	// matches carrying only a doc capture (no name/signature).
+	var comments []docComment
+
 	for {
 		match := matches.Next()
 		if match == nil {
@@ -312,6 +318,7 @@ func (p *TreeSitterParser) extractSignatures(
 
 		sig := parser.Signature{}
 		sigColumn := 0
+		docStartLine, docEndLine := 0, 0
 		var kindNode *sitter.Node
 
 		for _, capture := range match.Captures {
@@ -343,6 +350,8 @@ func (p *TreeSitterParser) extractSignatures(
 			case CaptureDoc:
 				if len(raw) > 0 {
 					sig.Doc = cleanComment(string(raw))
+					docStartLine = int(node.StartPosition().Row) + 1
+					docEndLine = int(node.EndPosition().Row) + 1
 				}
 			}
 		}
@@ -501,10 +510,72 @@ func (p *TreeSitterParser) extractSignatures(
 
 			sig.Language = opts.Language
 			signatures = append(signatures, sig)
+		} else if sig.Doc != "" && docEndLine > 0 {
+			// Standalone comment match: remember it for doc attachment.
+			comments = append(comments, docComment{
+				startLine: docStartLine,
+				endLine:   docEndLine,
+				text:      sig.Doc,
+			})
 		}
 	}
 
+	attachDocs(signatures, comments)
+
 	return signatures, nil
+}
+
+// docComment is a standalone documentation comment captured during signature
+// extraction, tracked by the source lines it spans so it can be attached to the
+// declaration it precedes.
+type docComment struct {
+	startLine int
+	endLine   int
+	text      string // already cleaned via cleanComment
+}
+
+// attachDocs connects standalone documentation comments to the signatures they
+// immediately precede. A comment whose last line sits directly above a
+// signature's start line is attached as that signature's Doc, matching the
+// godoc/JSDoc convention.
+func attachDocs(signatures []parser.Signature, comments []docComment) {
+	if len(comments) == 0 {
+		return
+	}
+
+	// Index comments by the line they end on for O(1) lookup above a declaration.
+	byEndLine := make(map[int]docComment, len(comments))
+	for _, c := range comments {
+		byEndLine[c.endLine] = c
+	}
+
+	for i := range signatures {
+		if signatures[i].Doc != "" {
+			continue // already attached (e.g. via an in-pattern @doc capture)
+		}
+
+		// Walk contiguous comment lines upward starting just above the
+		// declaration. A blank line breaks the run, matching godoc semantics.
+		line := signatures[i].Line - 1
+		var block []string
+		for {
+			c, ok := byEndLine[line]
+			if !ok {
+				break
+			}
+			block = append(block, c.text)
+			line = c.startLine - 1
+		}
+		if len(block) == 0 {
+			continue
+		}
+
+		// block was collected bottom-up; reverse into reading order.
+		for l, r := 0, len(block)-1; l < r; l, r = l+1, r-1 {
+			block[l], block[r] = block[r], block[l]
+		}
+		signatures[i].Doc = strings.Join(block, "\n")
+	}
 }
 
 // cleanComment removes comment markers from the text.

--- a/pkg/parser/treesitter/parser.go
+++ b/pkg/parser/treesitter/parser.go
@@ -319,6 +319,7 @@ func (p *TreeSitterParser) extractSignatures(
 		sig := parser.Signature{}
 		sigColumn := 0
 		docStartLine, docEndLine := 0, 0
+		docStandalone := false
 		var kindNode *sitter.Node
 
 		for _, capture := range match.Captures {
@@ -352,6 +353,7 @@ func (p *TreeSitterParser) extractSignatures(
 					sig.Doc = cleanComment(string(raw))
 					docStartLine = int(node.StartPosition().Row) + 1
 					docEndLine = int(node.EndPosition().Row) + 1
+					docStandalone = isStandaloneComment(content, start, int(node.StartPosition().Column))
 				}
 			}
 		}
@@ -510,8 +512,10 @@ func (p *TreeSitterParser) extractSignatures(
 
 			sig.Language = opts.Language
 			signatures = append(signatures, sig)
-		} else if sig.Doc != "" && docEndLine > 0 {
-			// Standalone comment match: remember it for doc attachment.
+		} else if sig.Doc != "" && docEndLine > 0 && docStandalone {
+			// Standalone (leading) comment match: remember it for doc
+			// attachment. Trailing/inline comments are skipped so they can't
+			// leak onto the following declaration.
 			comments = append(comments, docComment{
 				startLine: docStartLine,
 				endLine:   docEndLine,
@@ -551,7 +555,7 @@ func attachDocs(signatures []parser.Signature, comments []docComment) {
 
 	for i := range signatures {
 		if signatures[i].Doc != "" {
-			continue // already attached (e.g. via an in-pattern @doc capture)
+			continue // doc already set for this signature
 		}
 
 		// Walk contiguous comment lines upward starting just above the
@@ -576,6 +580,24 @@ func attachDocs(signatures []parser.Signature, comments []docComment) {
 		}
 		signatures[i].Doc = strings.Join(block, "\n")
 	}
+}
+
+// isStandaloneComment reports whether the comment beginning at startByte is the
+// first non-whitespace token on its line (a leading doc comment), as opposed to
+// a trailing/inline comment that follows code on the same line. column is the
+// comment's start column in bytes, as reported by tree-sitter.
+func isStandaloneComment(content []byte, startByte uint, column int) bool {
+	start := int(startByte)
+	lineStart := start - column
+	if column < 0 || lineStart < 0 || start > len(content) {
+		return true // be permissive if positions look inconsistent
+	}
+	for _, b := range content[lineStart:start] {
+		if b != ' ' && b != '\t' {
+			return false
+		}
+	}
+	return true
 }
 
 // cleanComment removes comment markers from the text.


### PR DESCRIPTION
## 개요

#322 수정 — doc 주석이 시그니처에 연결되지 않아 `<doc>` 출력이 **전 언어에서 하나도 렌더링되지 않던** 버그.

## 원인

전 언어가 `(comment) @doc`를 독립 최상위 패턴으로 정의 → 주석 매치에 name/signature 캡처가 없어 `parser.go`의 `sig.Name != "" && sig.Text != ""` 조건에서 드롭됨. 주석↔선언 연결 로직 부재.

## 변경

- **`attachDocs` 후처리**: 선언 시작 라인 바로 위 연속 주석 블록을 `Doc`에 연결 (godoc/JSDoc 관례). 빈 줄로 분리된 주석은 제외. 쿼리는 건드리지 않아 전 언어에 언어 독립적으로 적용.
- **Markdown 멀티라인 doc 렌더**: 각 줄에 blockquote(`> `) 마커 적용 (기존엔 첫 줄만 붙어 둘째 줄부터 인용 이탈).
- **테스트**: treesitter(단일/멀티라인/빈줄분리) + formatter(멀티라인 blockquote).

## 검증

- 전체 테스트 통과, `gofmt`/`go vet` clean
- 실측: 전체 프로젝트 XML `<doc>` **0개 → 569개**
- Python 등 다른 언어에서도 언어 독립적으로 동작 확인
- XML은 기존 `escapeXML`로 특수문자·멀티라인 안전

## 후속 (별도 이슈 예정)

- doc 길이 기본 상한(`MaxDocLength`) 정책 — A-2
- 블록주석 내부 ` * ` 마커 스트립 (JSDoc) — A-3

Closes #322